### PR TITLE
added troubleshooting link linking back to the docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Code-Search
 Code Search Admin scripts (SQL and PS) for managing a Code Search on-prem instance
+
+## Troubleshooting
+
+To find help on troubleshooting TFS follow this [link](https://www.visualstudio.com/en-us/docs/search/administration#trouble-tfs).


### PR DESCRIPTION
It's just easier if we have the link going back as well. I pull the repo down and because it doesn't have all the troubleshooting info in the repo it's nice to have the link going through