### PR TITLE
@RepositoryId incorrectly declared as empty string

### DIFF
--- a/TFS_2017RTW/SqlScripts/AddDataRe-IndexingJob.sql
+++ b/TFS_2017RTW/SqlScripts/AddDataRe-IndexingJob.sql
@@ -17,7 +17,7 @@ DECLARE @RepositoryName nvarchar(max) = $(RepositoryName)
 DECLARE @RepositoryType varchar(30) = $(RepositoryType)
 
 DECLARE @CollectionId uniqueidentifier = $(CollectionId)
-DECLARE @RepositoryId varchar(50) = ''
+DECLARE @RepositoryId varchar(50)
 if(@IndexingUnitType <> 'Collection')
 BEGIN
 	SELECT @RepositoryId = TFSEntityId from Search.tbl_IndexingUnit

--- a/TFS_2017Update1/SqlScripts/AddDataRe-IndexingJob.sql
+++ b/TFS_2017Update1/SqlScripts/AddDataRe-IndexingJob.sql
@@ -17,7 +17,7 @@ DECLARE @RepositoryName nvarchar(max) = $(RepositoryName)
 DECLARE @RepositoryType varchar(30) = $(RepositoryType)
 
 DECLARE @CollectionId uniqueidentifier = $(CollectionId)
-DECLARE @RepositoryId varchar(50) = ''
+DECLARE @RepositoryId varchar(50)
 if(@IndexingUnitType <> 'Collection')
 BEGIN
 	SELECT @RepositoryId = TFSEntityId from Search.tbl_IndexingUnit

--- a/TFS_2017Update2/SqlScripts/AddCodeRe-IndexingJobData.sql
+++ b/TFS_2017Update2/SqlScripts/AddCodeRe-IndexingJobData.sql
@@ -17,7 +17,7 @@ DECLARE @RepositoryName nvarchar(max) = $(RepositoryName)
 DECLARE @RepositoryType varchar(30) = $(RepositoryType)
 
 DECLARE @CollectionId uniqueidentifier = $(CollectionId)
-DECLARE @RepositoryId varchar(50) = ''
+DECLARE @RepositoryId varchar(50)
 if(@IndexingUnitType <> 'Collection')
 BEGIN
 	SELECT @RepositoryId = TFSEntityId from Search.tbl_IndexingUnit

--- a/TFS_2018RTW/SqlScripts/AddCodeRe-IndexingJobData.sql
+++ b/TFS_2018RTW/SqlScripts/AddCodeRe-IndexingJobData.sql
@@ -17,7 +17,7 @@ DECLARE @RepositoryName nvarchar(max) = $(RepositoryName)
 DECLARE @RepositoryType varchar(30) = $(RepositoryType) 
 
 DECLARE @CollectionId uniqueidentifier = $(CollectionId)
-DECLARE @RepositoryId varchar(50) = ''
+DECLARE @RepositoryId varchar(50)
 if(@IndexingUnitType <> 'Collection')
 BEGIN
 	SELECT @RepositoryId = TFSEntityId from Search.tbl_IndexingUnit


### PR DESCRIPTION
`@RepositoryId` is declared as an empty string. It means the `null` check on [L26](https://github.com/Microsoft/Code-Search/compare/master...ppejovic:master#diff-091939b18392fc11833123b4a3109e8bR26) of each file will never return `true`, even in the case where no repository id has been returned by the preceding select statement.

This caused an issue when I ran `Re-IndexingCodeRepository.ps1` with an incorrect TFVC repository (`Project` instead of `$/Project`) as it resulted in the code repair job being scheduled with bad data.