### PR TITLE
Recent indexing activity script fixes

### DIFF
--- a/TFS_2017Update1/SqlScripts/BulkIndexingActivity.sql
+++ b/TFS_2017Update1/SqlScripts/BulkIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as BulkIndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%BeginBulkIndex%Completed pipeline execution for IndexingUnit%'

--- a/TFS_2017Update1/SqlScripts/ContinuousIndexingActivity.sql
+++ b/TFS_2017Update1/SqlScripts/ContinuousIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(JobId) as ContinuousIndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%UpdateIndex%Completed pipeline execution for IndexingUnit%'

--- a/TFS_2017Update1/SqlScripts/CountRepositoryIndexingCompleted.sql
+++ b/TFS_2017Update1/SqlScripts/CountRepositoryIndexingCompleted.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as IndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%BeginBulkIndex-AccountFaultIn%Completed pipeline execution for IndexingUnit%'

--- a/TFS_2017Update2/SqlScripts/CodeBulkIndexingActivity.sql
+++ b/TFS_2017Update2/SqlScripts/CodeBulkIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as BulkIndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%BeginBulkIndex%Completed pipeline execution for IndexingUnit%EntityType: Code%'

--- a/TFS_2017Update2/SqlScripts/CodeContinuousIndexingActivity.sql
+++ b/TFS_2017Update2/SqlScripts/CodeContinuousIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(JobId) as ContinuousIndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%UpdateIndex%Completed pipeline execution for IndexingUnit%EntityType: Code%'

--- a/TFS_2017Update2/SqlScripts/CodeFailedIndexingActivity.sql
+++ b/TFS_2017Update2/SqlScripts/CodeFailedIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as FailedIndexingCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%events%completed with status Failed.%EntityType: Code%'

--- a/TFS_2017Update2/SqlScripts/CountCodeIndexingCompleted.sql
+++ b/TFS_2017Update2/SqlScripts/CountCodeIndexingCompleted.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as IndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%BeginBulkIndex-AccountFaultIn%Completed pipeline execution for IndexingUnit%EntityType: Code%'

--- a/TFS_2017Update2/SqlScripts/CountWorkItemIndexingCompleted.sql
+++ b/TFS_2017Update2/SqlScripts/CountWorkItemIndexingCompleted.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as IndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%BeginBulkIndex-AccountFaultIn%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'

--- a/TFS_2017Update2/SqlScripts/WorkItemBulkIndexingActivity.sql
+++ b/TFS_2017Update2/SqlScripts/WorkItemBulkIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as BulkIndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'

--- a/TFS_2017Update2/SqlScripts/WorkItemContinuousIndexingActivity.sql
+++ b/TFS_2017Update2/SqlScripts/WorkItemContinuousIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(JobId) as ContinuousIndexingCompletedCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%UpdateIndex%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'

--- a/TFS_2017Update2/SqlScripts/WorkItemFailedIndexingActivity.sql
+++ b/TFS_2017Update2/SqlScripts/WorkItemFailedIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as FailedIndexingCount from tbl_JobHistory
 where
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%events%completed with status Failed.%EntityType: WorkItem%'

--- a/TFS_2018RTW/SqlScripts/CodeBulkIndexingActivity.sql
+++ b/TFS_2018RTW/SqlScripts/CodeBulkIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as BulkIndexingCompletedCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ( ResultMessage like '%Git_Repository%Branches for BulkIndexing = (refs/heads%' or ResultMessage like '%Tfvc_Repository%BeginBulkIndex%Completed pipeline execution for IndexingUnit%EntityType: Code%')

--- a/TFS_2018RTW/SqlScripts/CodeContinuousIndexingActivity.sql
+++ b/TFS_2018RTW/SqlScripts/CodeContinuousIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(JobId) as ContinuousIndexingCompletedCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ( ResultMessage like '%Git_Repository%Branches for ContinuousIndexing = (refs/heads%' or ResultMessage like '%Tfvc_Repository%%UpdateIndex%Completed pipeline execution for IndexingUnit%EntityType: Code%')

--- a/TFS_2018RTW/SqlScripts/CodeFailedIndexingActivity.sql
+++ b/TFS_2018RTW/SqlScripts/CodeFailedIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as FailedIndexingCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%events%completed with status Failed.%EntityType: Code%'

--- a/TFS_2018RTW/SqlScripts/CountCodeIndexingCompleted.sql
+++ b/TFS_2018RTW/SqlScripts/CountCodeIndexingCompleted.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as IndexingCompletedCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%BeginBulkIndex-AccountFaultIn%Completed pipeline execution for IndexingUnit%EntityType: Code%'

--- a/TFS_2018RTW/SqlScripts/CountWorkItemIndexingCompleted.sql
+++ b/TFS_2018RTW/SqlScripts/CountWorkItemIndexingCompleted.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as IndexingCompletedCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%BeginBulkIndex-AccountFaultIn%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'

--- a/TFS_2018RTW/SqlScripts/WorkItemBulkIndexingActivity.sql
+++ b/TFS_2018RTW/SqlScripts/WorkItemBulkIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as BulkIndexingCompletedCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'

--- a/TFS_2018RTW/SqlScripts/WorkItemContinuousIndexingActivity.sql
+++ b/TFS_2018RTW/SqlScripts/WorkItemContinuousIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(JobId) as ContinuousIndexingCompletedCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%UpdateIndex%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'

--- a/TFS_2018RTW/SqlScripts/WorkItemFailedIndexingActivity.sql
+++ b/TFS_2018RTW/SqlScripts/WorkItemFailedIndexingActivity.sql
@@ -9,5 +9,5 @@ Declare @Days int = $(DaysAgo);
 Select Count(Distinct(JobId)) as FailedIndexingCount from tbl_JobHistory
 where 
 JobSource = @CollectionId
-and QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
 and ResultMessage like '%events%completed with status Failed.%EntityType: WorkItem%'


### PR DESCRIPTION
Updates to use EndTime instead of QueueTime in the JobHistory query.