### PR TITLE
(GH-66) Change download link to latest JDK version

### DIFF
--- a/Java Migration/Azure_DevOps_Server_2019.md
+++ b/Java Migration/Azure_DevOps_Server_2019.md
@@ -20,7 +20,7 @@ cd "C:\Program Files\Azure DevOps Server 2019\Search\ES\elasticsearchv5\bin"
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2017 RTW.md
+++ b/Java Migration/TFS_2017 RTW.md
@@ -21,7 +21,7 @@ execute "service.bat stop"
 execute "service.bat remove"
 
 ## Step 4: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 7u201](https://cdn.azul.com/zulu/bin/zulu7.25.0.5-jdk7.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 7](https://www.azul.com/downloads/zulu-community/?&version=java-7-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 5: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2017Update1.md
+++ b/Java Migration/TFS_2017Update1.md
@@ -19,7 +19,7 @@ cd "C:\Program Files\Microsoft Team Foundation Server 15.0\Search\ES\elasticsear
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2017Update2.md
+++ b/Java Migration/TFS_2017Update2.md
@@ -19,7 +19,7 @@ cd "C:\Program Files\Microsoft Team Foundation Server 15.0\Search\ES\elasticsear
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2017Update3.md
+++ b/Java Migration/TFS_2017Update3.md
@@ -19,7 +19,7 @@ cd "C:\Program Files\Microsoft Team Foundation Server 15.0\Search\ES\elasticsear
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2018RTW.md
+++ b/Java Migration/TFS_2018RTW.md
@@ -20,7 +20,7 @@ cd "C:\Program Files\Microsoft Team Foundation Server 2018\Search\ES\elasticsear
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2018Update1.md
+++ b/Java Migration/TFS_2018Update1.md
@@ -20,7 +20,7 @@ cd "C:\Program Files\Microsoft Team Foundation Server 2018\Search\ES\elasticsear
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2018Update2.md
+++ b/Java Migration/TFS_2018Update2.md
@@ -19,7 +19,7 @@ cd "C:\Program Files\Microsoft Team Foundation Server 2018\Search\ES\elasticsear
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)

--- a/Java Migration/TFS_2018Update3.md
+++ b/Java Migration/TFS_2018Update3.md
@@ -19,7 +19,7 @@ cd "C:\Program Files\Microsoft Team Foundation Server 2018\Search\ES\elasticsear
 execute "elasticsearch-service.bat stop"
 
 ## Step 3: Download and Install Azul Zulu Java 
-Download and install [OpenJDK 8u201](https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-win_x64.msi)
+Download and install latest version of [OpenJDK 8](https://www.azul.com/downloads/zulu-community/?&version=java-8-lts&os=windows&os-details=Windows&architecture=x86-64-bit&package=jdk)
 
 ## Step 4: Update JAVA_HOME with Azul Zulu path
 ![Update Java Home](java_home.png)


### PR DESCRIPTION
Change download ink to latest version of JDK. I assumed that x64 is a requirement, otherwise I can change links to offer x86 and x64 downloads.

Fixes #66 