### PR TITLE
Changed the IUCE descriptor version for Azure Devops 2019 sql scripts

### DIFF
--- a/Azure_DevOps_Server_2019/SqlScripts/AddFilesToBeIndexed.sql
+++ b/Azure_DevOps_Server_2019/SqlScripts/AddFilesToBeIndexed.sql
@@ -97,7 +97,7 @@ SELECT @ChangeData = FORMATMESSAGE('<ChangeEventData i:type="RepositoryPatchEven
 DECLARE @Prerequisites NVARCHAR(MAX)
 SET @Prerequisites = '<IndexingUnitChangeEventPrerequisites i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"/>'
 
-DECLARE @ItemList Search.typ_IndexingUnitChangeEventDescriptorV2;
-INSERT INTO @ItemList values (@RepositoryIndexingUnitId, 'Patch', @ChangeData, NULL, 'Pending', 0, @Prerequisites, NULL);
+DECLARE @ItemList Search.typ_IndexingUnitChangeEventDescriptorV3;
+INSERT INTO @ItemList values (@RepositoryIndexingUnitId, 'Patch', @ChangeData, NULL, 'Pending', 0, @Prerequisites, NULL, 14);
 
 EXEC Search.prc_AddEntryForIndexingUnitChangeEvent @PartitionID, @ItemList

--- a/Azure_DevOps_Server_2019/SqlScripts/AddRepositoryUpdateMetadataChangeEvent.sql
+++ b/Azure_DevOps_Server_2019/SqlScripts/AddRepositoryUpdateMetadataChangeEvent.sql
@@ -59,7 +59,7 @@ SET @ChangeData = REPLACE(@ChangeData, '$CorrelationId', NEWID())
 DECLARE @Prerequisites nvarchar(max)
 SET @Prerequisites = '<IndexingUnitChangeEventPrerequisites i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"/>'
 
-DECLARE @ItemList Search.typ_IndexingUnitChangeEventDescriptorV2;
-INSERT INTO @ItemList values (@RepositoryIndexingUnitId, 'UpdateMetadata', @ChangeData, NULL, 'Pending', 0, @Prerequisites, NULL);
+DECLARE @ItemList Search.typ_IndexingUnitChangeEventDescriptorV3;
+INSERT INTO @ItemList values (@RepositoryIndexingUnitId, 'UpdateMetadata', @ChangeData, NULL, 'Pending', 0, @Prerequisites, NULL, 0);
 
 EXEC Search.prc_AddEntryForIndexingUnitChangeEvent @PartitionID, @ItemList


### PR DESCRIPTION
Pull request to change the IUCE descriptor version for Azure Devops server 2019 in two sql scripts. 
The new version has an extra column for JobTrigger. 
Added that as well according to the changed data