### PR TITLE
Update GetRepositoryReIndexingActivityStatus.ps1

### DIFF
--- a/Azure_DevOps_Server_2019/GetRepositoryReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2019/GetRepositoryReIndexingActivityStatus.ps1
@@ -1,4 +1,5 @@
 ﻿#Display respository indexing status for a given collection.
+#Go to the code srach url i.e. localhost:9200/_cat/indices and check the index names (ex. wikixxx, coexxx etc.) and replace it with codesearchshared*
 
 [CmdletBinding()]
 Param(


### PR DESCRIPTION
most of the customer do not understand the codesearchshared* parameter and consider it as a part of search.

I have added the explanation what to replace it with while running the script locally.