### PR TITLE
Support for use of "trustservercertificate" option in AzD 2022 scripts if they use Invoke-Sqlcmd

### DIFF
--- a/Azure_DevOps_Server_2022/CleanUpShardDetails.ps1
+++ b/Azure_DevOps_Server_2022/CleanUpShardDetails.ps1
@@ -8,7 +8,7 @@ Param(
     [string]$SQLServerInstance,
 
     [Parameter(Mandatory=$True, Position=1, HelpMessage="Configuration DB")]
-    [string]$ConfigurationDatabaseName
+    [string]$ConfigurationDatabaseName,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -16,8 +16,9 @@ Param(
 
 function CleanupShardDetails
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CleanUpShardDetailsTable.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose @trustCertParam
     Write-Host "Cleaned up the shard details..." -ForegroundColor Yellow
 }
 

--- a/Azure_DevOps_Server_2022/CleanUpShardDetails.ps1
+++ b/Azure_DevOps_Server_2022/CleanUpShardDetails.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 This scripts cleans the shard details table from the configuration database
 #>
 
@@ -9,12 +9,15 @@ Param(
 
     [Parameter(Mandatory=$True, Position=1, HelpMessage="Configuration DB")]
     [string]$ConfigurationDatabaseName
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 function CleanupShardDetails
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CleanUpShardDetailsTable.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Cleaned up the shard details..." -ForegroundColor Yellow
 }
 

--- a/Azure_DevOps_Server_2022/Common.psm1
+++ b/Azure_DevOps_Server_2022/Common.psm1
@@ -34,8 +34,7 @@ function ValidateCollectionName
     (
         [string] $SQLServerInstance,
         [string] $ConfigurationDatabaseName,
-        [string] $CollectionName
-
+        [string] $CollectionName,
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
@@ -61,14 +60,11 @@ function IsExtensionInstalled
     (
         [string] $SQLServerInstance,
         [string] $CollectionDatabaseName,
-        [string] $RegValue
-
+        [string] $RegValue,
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
-
-    return $true
 
     $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam
 

--- a/Azure_DevOps_Server_2022/Common.psm1
+++ b/Azure_DevOps_Server_2022/Common.psm1
@@ -35,9 +35,12 @@ function ValidateCollectionName
         [string] $SQLServerInstance,
         [string] $ConfigurationDatabaseName,
         [string] $CollectionName
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
-    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName' and HostType = 4" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Verbose
+    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName' and HostType = 4" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Verbose -TrustServerCertificate:$TrustServerCertificate
 
     $CollectionID = $queryResults  | Select-object  -ExpandProperty  HOSTID
 
@@ -58,11 +61,14 @@ function IsExtensionInstalled
         [string] $SQLServerInstance,
         [string] $CollectionDatabaseName,
         [string] $RegValue
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     return $true
 
-    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName
+    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 
     if($isCollectionIndexed.RegValue -eq "True")
     {

--- a/Azure_DevOps_Server_2022/Common.psm1
+++ b/Azure_DevOps_Server_2022/Common.psm1
@@ -39,8 +39,9 @@ function ValidateCollectionName
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
-    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName' and HostType = 4" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Verbose -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName' and HostType = 4" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Verbose @trustCertParam
 
     $CollectionID = $queryResults  | Select-object  -ExpandProperty  HOSTID
 
@@ -65,10 +66,11 @@ function IsExtensionInstalled
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     return $true
 
-    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam
 
     if($isCollectionIndexed.RegValue -eq "True")
     {

--- a/Azure_DevOps_Server_2022/ExcludedTfvcFoldersForIndexing.ps1
+++ b/Azure_DevOps_Server_2022/ExcludedTfvcFoldersForIndexing.ps1
@@ -65,7 +65,8 @@ function DeleteAllExcludedFolders
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
 switch ($OperationType)
 {

--- a/Azure_DevOps_Server_2022/ExcludedTfvcFoldersForIndexing.ps1
+++ b/Azure_DevOps_Server_2022/ExcludedTfvcFoldersForIndexing.ps1
@@ -13,7 +13,7 @@ Param(
     [string]$CollectionName,
     
 	[Parameter(Mandatory=$True, Position=4, HelpMessage="Enter operation type 'Add' for adding more folder(s), 'Remove' for removing folder(s) from exclusion list, 'Delete' for deleting all the folders in the list, 'Fetch' for fetching list of folders present in exclusion list.")]
-    [string]$OperationType
+    [string]$OperationType,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -23,18 +23,20 @@ Import-Module .\Common.psm1 -Force
 
 function AddExcludedFolders
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 	$foldersList = Read-Host 'Specify comma separated list of folders to Exclude from Indexing'
 	$Params = "CollectionId='$CollectionID'", "FolderPaths='$foldersList'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\AddFoldersInExclusionList.sql'
-	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params @trustCertParam
 	Write-Host "Added Given folders to Indexing Exclusion list" -ForegroundColor Yellow
 }
 
 function FetchExcludedFoldersList
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 	$Params = "CollectionId='$CollectionID'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\FetchFoldersInExclusionList.sql'
-	$QueryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+	$QueryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params @trustCertParam
 	
 	$ExcludedFoldersList = $QueryResults | Select-object -ExpandProperty ExcludedFolders	
 	Write-Host "Folders present in Indexing Exclusion list are: '$ExcludedFoldersList'" -ForegroundColor Yellow
@@ -42,18 +44,20 @@ function FetchExcludedFoldersList
 
 function RemoveFoldersFromExclusionList
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 	$foldersList = Read-Host 'Specify comma separated list of folders to remove from Indexing Exclusion list'
 	$Params = "CollectionId='$CollectionID'", "FolderPaths='$foldersList'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\RemoveFoldersFromExclusionList.sql'
-	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params @trustCertParam
 	Write-Host "Removed given folders from Indexing Exclusion list" -ForegroundColor Yellow
 }
 
 function DeleteAllExcludedFolders
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 	$Params = "CollectionId='$CollectionID'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\DeleteAllFoldersInExclusionList.sql'
-	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params @trustCertParam
 	Write-Host "Deleted all folders from Indexing Exclusion list" -ForegroundColor Yellow
 }
 

--- a/Azure_DevOps_Server_2022/ExcludedTfvcFoldersForIndexing.ps1
+++ b/Azure_DevOps_Server_2022/ExcludedTfvcFoldersForIndexing.ps1
@@ -14,6 +14,9 @@ Param(
     
 	[Parameter(Mandatory=$True, Position=4, HelpMessage="Enter operation type 'Add' for adding more folder(s), 'Remove' for removing folder(s) from exclusion list, 'Delete' for deleting all the folders in the list, 'Fetch' for fetching list of folders present in exclusion list.")]
     [string]$OperationType
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 Import-Module .\Common.psm1 -Force
@@ -23,7 +26,7 @@ function AddExcludedFolders
 	$foldersList = Read-Host 'Specify comma separated list of folders to Exclude from Indexing'
 	$Params = "CollectionId='$CollectionID'", "FolderPaths='$foldersList'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\AddFoldersInExclusionList.sql'
-	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
 	Write-Host "Added Given folders to Indexing Exclusion list" -ForegroundColor Yellow
 }
 
@@ -31,7 +34,7 @@ function FetchExcludedFoldersList
 {
 	$Params = "CollectionId='$CollectionID'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\FetchFoldersInExclusionList.sql'
-	$QueryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	$QueryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
 	
 	$ExcludedFoldersList = $QueryResults | Select-object -ExpandProperty ExcludedFolders	
 	Write-Host "Folders present in Indexing Exclusion list are: '$ExcludedFoldersList'" -ForegroundColor Yellow
@@ -42,7 +45,7 @@ function RemoveFoldersFromExclusionList
 	$foldersList = Read-Host 'Specify comma separated list of folders to remove from Indexing Exclusion list'
 	$Params = "CollectionId='$CollectionID'", "FolderPaths='$foldersList'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\RemoveFoldersFromExclusionList.sql'
-	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
 	Write-Host "Removed given folders from Indexing Exclusion list" -ForegroundColor Yellow
 }
 
@@ -50,7 +53,7 @@ function DeleteAllExcludedFolders
 {
 	$Params = "CollectionId='$CollectionID'"
 	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\DeleteAllFoldersInExclusionList.sql'
-	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params -TrustServerCertificate:$TrustServerCertificate
 	Write-Host "Deleted all folders from Indexing Exclusion list" -ForegroundColor Yellow
 }
 
@@ -58,7 +61,7 @@ function DeleteAllExcludedFolders
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
 switch ($OperationType)
 {

--- a/Azure_DevOps_Server_2022/ExtensionInstallIndexingStatus.ps1
+++ b/Azure_DevOps_Server_2022/ExtensionInstallIndexingStatus.ps1
@@ -16,7 +16,7 @@ Param(
     [string]$Days,
     
     [Parameter(Mandatory=$False, Position=5, HelpMessage="Extension install indexing state for Code, WorkItem, Wiki or All")]
-    [string]$EntityType = "All"
+    [string]$EntityType = "All",
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -27,12 +27,13 @@ Import-Module .\Common.psm1 -Force
 # Fetches the Code Extension install indexing status.
 function CodeExtensionInstallIndexingStatus
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     # Validating if the collection has code extension installed.
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
     {
         #Gets the result of the Code Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeAccountFaultInResult.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile "$PWD\SqlScripts\CodeAccountFaultInResult.sql" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile "$PWD\SqlScripts\CodeAccountFaultInResult.sql" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
     
         if($queryResults)
         {
@@ -50,7 +51,7 @@ function CodeExtensionInstallIndexingStatus
 
             # Gets the count of repositories for which the code indexing has completed.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CountCodeIndexingCompleted.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
             $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
             if($indexingCompletedRepositoryCount -gt 0)
@@ -64,7 +65,7 @@ function CodeExtensionInstallIndexingStatus
         
             # Gets the data for repositories which are still inprogress.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeBulkIndexingInProgressRepositoryCount.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params @trustCertParam
             $CodeBulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ItemArray
 
             if($CodeBulkIndexingInProgressRepositoryCount -gt 0)
@@ -96,12 +97,13 @@ function CodeExtensionInstallIndexingStatus
 
 function WorkItemExtensionInstallIndexingStatus
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     # Validating if the collection has workitem extension installed.
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
     {
         #Gets the result of the Code Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemAccountFaultInResult.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
     
         if($queryResults)
         {
@@ -119,7 +121,7 @@ function WorkItemExtensionInstallIndexingStatus
 
             # Gets the count of repositories for which the indexing has completed.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CountWorkItemIndexingCompleted.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
             $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
             if($indexingCompletedRepositoryCount -gt 0)
@@ -133,7 +135,7 @@ function WorkItemExtensionInstallIndexingStatus
         
             # Gets the data for projects with workitem indexing still inprogress.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemIndexingInProgressRepositoryCount.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params @trustCertParam
             $WorkItemIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ItemArray
 
             if($WorkItemIndexingInProgressRepositoryCount -gt 0)
@@ -165,12 +167,13 @@ function WorkItemExtensionInstallIndexingStatus
 # Fetches the Wiki Extension install indexing status.
 function WikiExtensionInstallIndexingStatus
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     # Validating if the collection has wiki search extension installed.
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
     {
         #Gets the result of the Wiki Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiAccountFaultInResult.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
 
         if($queryResults)
         {
@@ -188,7 +191,7 @@ function WikiExtensionInstallIndexingStatus
 
             # Gets the count of repositories for which the wiki indexing has completed.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingCompletedActivity.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
             $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
             if($indexingCompletedRepositoryCount -gt 0)
@@ -202,7 +205,7 @@ function WikiExtensionInstallIndexingStatus
 
             # Gets the data for repositories which are still inprogress.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingInProgressRepositories.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params @trustCertParam
             $WikiIndexingInProgressRepositories = $queryResults  | Select-object  -ExpandProperty  ItemArray
 
             if($WikiIndexingInProgressRepositories -gt 0)

--- a/Azure_DevOps_Server_2022/ExtensionInstallIndexingStatus.ps1
+++ b/Azure_DevOps_Server_2022/ExtensionInstallIndexingStatus.ps1
@@ -24,12 +24,14 @@ Param(
 
 Import-Module .\Common.psm1 -Force
 
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
+
 # Fetches the Code Extension install indexing status.
 function CodeExtensionInstallIndexingStatus
 {
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     # Validating if the collection has code extension installed.
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
     {
         #Gets the result of the Code Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeAccountFaultInResult.sql'
@@ -99,7 +101,7 @@ function WorkItemExtensionInstallIndexingStatus
 {
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     # Validating if the collection has workitem extension installed.
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" @trustCertParam)
     {
         #Gets the result of the Code Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemAccountFaultInResult.sql'
@@ -169,7 +171,7 @@ function WikiExtensionInstallIndexingStatus
 {
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     # Validating if the collection has wiki search extension installed.
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" @trustCertParam)
     {
         #Gets the result of the Wiki Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiAccountFaultInResult.sql'
@@ -241,7 +243,7 @@ Push-Location
 ImportSQLModule
 
 # Checking for valid Collection Name.
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
 $Params = "CollectionId='$CollectionID'" 
 $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"

--- a/Azure_DevOps_Server_2022/ExtensionInstallIndexingStatus.ps1
+++ b/Azure_DevOps_Server_2022/ExtensionInstallIndexingStatus.ps1
@@ -17,6 +17,9 @@ Param(
     
     [Parameter(Mandatory=$False, Position=5, HelpMessage="Extension install indexing state for Code, WorkItem, Wiki or All")]
     [string]$EntityType = "All"
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 Import-Module .\Common.psm1 -Force
@@ -25,11 +28,11 @@ Import-Module .\Common.psm1 -Force
 function CodeExtensionInstallIndexingStatus
 {
     # Validating if the collection has code extension installed.
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
     {
         #Gets the result of the Code Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeAccountFaultInResult.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile "$PWD\SqlScripts\CodeAccountFaultInResult.sql" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+        $queryResults = Invoke-Sqlcmd -InputFile "$PWD\SqlScripts\CodeAccountFaultInResult.sql" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
     
         if($queryResults)
         {
@@ -47,7 +50,7 @@ function CodeExtensionInstallIndexingStatus
 
             # Gets the count of repositories for which the code indexing has completed.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CountCodeIndexingCompleted.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
             $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
             if($indexingCompletedRepositoryCount -gt 0)
@@ -61,7 +64,7 @@ function CodeExtensionInstallIndexingStatus
         
             # Gets the data for repositories which are still inprogress.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeBulkIndexingInProgressRepositoryCount.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
             $CodeBulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ItemArray
 
             if($CodeBulkIndexingInProgressRepositoryCount -gt 0)
@@ -94,11 +97,11 @@ function CodeExtensionInstallIndexingStatus
 function WorkItemExtensionInstallIndexingStatus
 {
     # Validating if the collection has workitem extension installed.
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
     {
         #Gets the result of the Code Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemAccountFaultInResult.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
     
         if($queryResults)
         {
@@ -116,7 +119,7 @@ function WorkItemExtensionInstallIndexingStatus
 
             # Gets the count of repositories for which the indexing has completed.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CountWorkItemIndexingCompleted.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
             $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
             if($indexingCompletedRepositoryCount -gt 0)
@@ -130,7 +133,7 @@ function WorkItemExtensionInstallIndexingStatus
         
             # Gets the data for projects with workitem indexing still inprogress.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemIndexingInProgressRepositoryCount.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
             $WorkItemIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ItemArray
 
             if($WorkItemIndexingInProgressRepositoryCount -gt 0)
@@ -163,11 +166,11 @@ function WorkItemExtensionInstallIndexingStatus
 function WikiExtensionInstallIndexingStatus
 {
     # Validating if the collection has wiki search extension installed.
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
     {
         #Gets the result of the Wiki Extension AccountFaultIn job
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiAccountFaultInResult.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
 
         if($queryResults)
         {
@@ -185,7 +188,7 @@ function WikiExtensionInstallIndexingStatus
 
             # Gets the count of repositories for which the wiki indexing has completed.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingCompletedActivity.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
             $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
             if($indexingCompletedRepositoryCount -gt 0)
@@ -199,7 +202,7 @@ function WikiExtensionInstallIndexingStatus
 
             # Gets the data for repositories which are still inprogress.
             $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingInProgressRepositories.sql'
-            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
             $WikiIndexingInProgressRepositories = $queryResults  | Select-object  -ExpandProperty  ItemArray
 
             if($WikiIndexingInProgressRepositories -gt 0)
@@ -235,7 +238,7 @@ Push-Location
 ImportSQLModule
 
 # Checking for valid Collection Name.
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
 $Params = "CollectionId='$CollectionID'" 
 $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"

--- a/Azure_DevOps_Server_2022/FixIndexingIndexName.ps1
+++ b/Azure_DevOps_Server_2022/FixIndexingIndexName.ps1
@@ -23,7 +23,7 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
 # Fix the index name in all repo indexing units
 $fixIndexingIndexNameParams = "CollectionId='$CollectionID'"

--- a/Azure_DevOps_Server_2022/FixIndexingIndexName.ps1
+++ b/Azure_DevOps_Server_2022/FixIndexingIndexName.ps1
@@ -10,11 +10,12 @@ Param(
     [string]$ConfigurationDatabaseName,
    
     [Parameter(Mandatory=$True, Position=3, HelpMessage="Enter the Collection Name here.")]
-    [string]$CollectionName
+    [string]$CollectionName,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
 )
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
 Import-Module .\Common.psm1 -Force
 
@@ -27,7 +28,7 @@ $CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabase
 # Fix the index name in all repo indexing units
 $fixIndexingIndexNameParams = "CollectionId='$CollectionID'"
 $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\FixIndexingIndexName.sql'
-Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $fixIndexingIndexNameParams -TrustServerCertificate:$TrustServerCertificate
+Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $fixIndexingIndexNameParams @trustCertParam
 Write-Host "Fixed the indexing index name in all repo indexing units" -ForegroundColor Cyan
 
 Pop-Location

--- a/Azure_DevOps_Server_2022/FixIndexingIndexName.ps1
+++ b/Azure_DevOps_Server_2022/FixIndexingIndexName.ps1
@@ -11,6 +11,9 @@ Param(
    
     [Parameter(Mandatory=$True, Position=3, HelpMessage="Enter the Collection Name here.")]
     [string]$CollectionName
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 Import-Module .\Common.psm1 -Force
@@ -19,12 +22,12 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
 # Fix the index name in all repo indexing units
 $fixIndexingIndexNameParams = "CollectionId='$CollectionID'"
 $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\FixIndexingIndexName.sql'
-Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $fixIndexingIndexNameParams
+Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $fixIndexingIndexNameParams -TrustServerCertificate:$TrustServerCertificate
 Write-Host "Fixed the indexing index name in all repo indexing units" -ForegroundColor Cyan
 
 Pop-Location

--- a/Azure_DevOps_Server_2022/GetCollectionReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2022/GetCollectionReIndexingActivityStatus.ps1
@@ -34,6 +34,7 @@ Param(
 
 function getCollectionIndexingStatus
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     if(!$ConfigurationDatabaseName -or !$CollectionDatabaseName)
     {
         Write-Host "Please enter ConfigurationDatabaseName and CollectionDatabaseName"
@@ -42,12 +43,12 @@ function getCollectionIndexingStatus
     Import-Module .\Common.psm1 -Force
     $collectionId = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $userCollection -TrustServerCertificate:$TrustServerCertificate
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeIndexingCompletedCount.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName @trustCertParam
     $completed =  $queryResults.BulkIndexingCompletedCount
     Write-Host "No of repositories completed: $completed"
                                               
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeIndexingInProgressRepositories.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName @trustCertParam
     $inProgress = $queryResults.Length
     Write-Host "Repositories InProgress: $inProgress"
     if($inProgress -gt 0)

--- a/Azure_DevOps_Server_2022/GetCollectionReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2022/GetCollectionReIndexingActivityStatus.ps1
@@ -1,4 +1,4 @@
-﻿#Display collection indexing status for a given collection.
+#Display collection indexing status for a given collection.
 
 [CmdletBinding()]
 Param(
@@ -25,7 +25,10 @@ Param(
 
     [Parameter(Mandatory=$False, Position=5, HelpMessage="URI for Elasticsearch instance.")]
     [String]
-    $Uri
+    $Uri,
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 
@@ -37,14 +40,14 @@ function getCollectionIndexingStatus
         return
     }
     Import-Module .\Common.psm1 -Force
-    $collectionId = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $userCollection
+    $collectionId = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $userCollection -TrustServerCertificate:$TrustServerCertificate
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeIndexingCompletedCount.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
     $completed =  $queryResults.BulkIndexingCompletedCount
     Write-Host "No of repositories completed: $completed"
                                               
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeIndexingInProgressRepositories.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
     $inProgress = $queryResults.Length
     Write-Host "Repositories InProgress: $inProgress"
     if($inProgress -gt 0)

--- a/Azure_DevOps_Server_2022/GetCollectionReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2022/GetCollectionReIndexingActivityStatus.ps1
@@ -41,7 +41,7 @@ function getCollectionIndexingStatus
         return
     }
     Import-Module .\Common.psm1 -Force
-    $collectionId = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $userCollection -TrustServerCertificate:$TrustServerCertificate
+    $collectionId = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $userCollection @trustCertParam
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeIndexingCompletedCount.sql'
     $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName @trustCertParam
     $completed =  $queryResults.BulkIndexingCompletedCount

--- a/Azure_DevOps_Server_2022/GetElasticsearchDocCountPerRepository.ps1
+++ b/Azure_DevOps_Server_2022/GetElasticsearchDocCountPerRepository.ps1
@@ -11,10 +11,7 @@ Param(
 
     [Parameter(Mandatory=$True, Position=1, HelpMessage="Destination where the output file will be saved.")]
     [String]
-    $Destination,
-
-    [Parameter(Mandatory=$False)]
-    [switch]$TrustServerCertificate
+    $Destination
 )
 
 $contractTypes= @{}

--- a/Azure_DevOps_Server_2022/GetElasticsearchDocCountPerRepository.ps1
+++ b/Azure_DevOps_Server_2022/GetElasticsearchDocCountPerRepository.ps1
@@ -1,4 +1,4 @@
-﻿#Fetch repository documents count data from provided ES instance.
+#Fetch repository documents count data from provided ES instance.
 #Run the script with script <ES Connection String> <Destination>
 #Output will be stored in a single json file at the given destination.
 #Format of the output is same as the one returned by elasticsearch for nested aggregation queries.
@@ -12,6 +12,10 @@ Param(
     [Parameter(Mandatory=$True, Position=1, HelpMessage="Destination where the output file will be saved.")]
     [String]
     $Destination
+,
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 $contractTypes= @{}

--- a/Azure_DevOps_Server_2022/GetElasticsearchDocCountPerRepository.ps1
+++ b/Azure_DevOps_Server_2022/GetElasticsearchDocCountPerRepository.ps1
@@ -11,8 +11,7 @@ Param(
 
     [Parameter(Mandatory=$True, Position=1, HelpMessage="Destination where the output file will be saved.")]
     [String]
-    $Destination
-,
+    $Destination,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate

--- a/Azure_DevOps_Server_2022/GetReIndexingStatusOfFiles.ps1
+++ b/Azure_DevOps_Server_2022/GetReIndexingStatusOfFiles.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 This script configures a path of a repository for re-indexing.
 #>
 
@@ -24,6 +24,9 @@ Param(
 
     [Parameter(Mandatory=$True, Position=6, HelpMessage="File/Folder for which re-index status has to be checked.")]
     [string]$Path
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 IF ([string]::IsNullOrWhiteSpace($SQLServerInstance) -Or 
@@ -58,13 +61,13 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
 {
     $GetReIndexingStatusParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","Path='$Path'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\GetReIndexingStatusOfFiles.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $GetReIndexingStatusParams
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $GetReIndexingStatusParams -TrustServerCertificate:$TrustServerCertificate
     
     if ($queryResults)
     {

--- a/Azure_DevOps_Server_2022/GetReIndexingStatusOfFiles.ps1
+++ b/Azure_DevOps_Server_2022/GetReIndexingStatusOfFiles.ps1
@@ -23,11 +23,12 @@ Param(
     [string]$RepositoryName,
 
     [Parameter(Mandatory=$True, Position=6, HelpMessage="File/Folder for which re-index status has to be checked.")]
-    [string]$Path
+    [string]$Path,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
 )
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
 IF ([string]::IsNullOrWhiteSpace($SQLServerInstance) -Or 
     [string]::IsNullOrWhiteSpace($CollectionDatabaseName) -Or 
@@ -67,7 +68,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 {
     $GetReIndexingStatusParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","Path='$Path'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\GetReIndexingStatusOfFiles.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $GetReIndexingStatusParams -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $GetReIndexingStatusParams @trustCertParam
     
     if ($queryResults)
     {

--- a/Azure_DevOps_Server_2022/GetReIndexingStatusOfFiles.ps1
+++ b/Azure_DevOps_Server_2022/GetReIndexingStatusOfFiles.ps1
@@ -62,9 +62,9 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
 {
     $GetReIndexingStatusParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","Path='$Path'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\GetReIndexingStatusOfFiles.sql'

--- a/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
@@ -21,8 +21,7 @@ Param(
 
     [Parameter(Mandatory=$True, Position=4, HelpMessage="URI for Elasticsearch instance.")]
     [String]
-    $Uri
-,
+    $Uri,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate

--- a/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
@@ -21,10 +21,7 @@ Param(
 
     [Parameter(Mandatory=$True, Position=4, HelpMessage="URI for Elasticsearch instance.")]
     [String]
-    $Uri,
-
-    [Parameter(Mandatory=$False)]
-    [switch]$TrustServerCertificate
+    $Uri
 )
 
 

--- a/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
@@ -1,4 +1,4 @@
-#Display respository indexing status for a given collection.
+#Display repository indexing status for a given collection.
 
 [CmdletBinding()]
 Param(

--- a/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
+++ b/Azure_DevOps_Server_2022/GetRepositoryReIndexingActivityStatus.ps1
@@ -1,4 +1,4 @@
-﻿#Display respository indexing status for a given collection.
+#Display respository indexing status for a given collection.
 
 [CmdletBinding()]
 Param(
@@ -22,6 +22,10 @@ Param(
     [Parameter(Mandatory=$True, Position=4, HelpMessage="URI for Elasticsearch instance.")]
     [String]
     $Uri
+,
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 

--- a/Azure_DevOps_Server_2022/MissingIndexFolderTriggerCollectionIndexing.ps1
+++ b/Azure_DevOps_Server_2022/MissingIndexFolderTriggerCollectionIndexing.ps1
@@ -10,18 +10,20 @@ Param(
     [string]$ConfigurationDatabaseName,
    
     [Parameter(Mandatory=$True, Position=3, HelpMessage="Enter the Collection Name here.")]
-    [string]$CollectionName
+    [string]$CollectionName,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
 )
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
 Import-Module .\Common.psm1 -Force
 
 function CleanUpIndexingState
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CleanUpCollectionIndexingState_IndexDelete.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
     Write-Host "Cleaned up the Collection Indexing state..." -ForegroundColor Yellow    
 }
 
@@ -39,7 +41,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
     $Params = "CollectionId='$CollectionID'"
 
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueCodeExtensionInstallIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
     Write-Host "Successfully queued the Code Indexing job for the collection!!" -ForegroundColor Green
 }
 else
@@ -53,7 +55,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
     $Params = "CollectionId='$CollectionID'"
 
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueWorkItemExtensionInstallIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
     Write-Host "Successfully queued the WorkItem Indexing job for the collection!!" -ForegroundColor Green
 }
 else
@@ -67,7 +69,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
     $Params = "CollectionId='$CollectionID'"
 
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueWikiExtensionInstallIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
     Write-Host "Successfully queued the Wiki Indexing job for the collection!!" -ForegroundColor Green
 }
 else

--- a/Azure_DevOps_Server_2022/MissingIndexFolderTriggerCollectionIndexing.ps1
+++ b/Azure_DevOps_Server_2022/MissingIndexFolderTriggerCollectionIndexing.ps1
@@ -11,6 +11,9 @@ Param(
    
     [Parameter(Mandatory=$True, Position=3, HelpMessage="Enter the Collection Name here.")]
     [string]$CollectionName
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 Import-Module .\Common.psm1 -Force
@@ -18,7 +21,7 @@ Import-Module .\Common.psm1 -Force
 function CleanUpIndexingState
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CleanUpCollectionIndexingState_IndexDelete.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Cleaned up the Collection Indexing state..." -ForegroundColor Yellow    
 }
 
@@ -26,17 +29,17 @@ function CleanUpIndexingState
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
 CleanUpIndexingState
 
 # Queue Collection code indexing job.
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
 {
     $Params = "CollectionId='$CollectionID'"
 
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueCodeExtensionInstallIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Successfully queued the Code Indexing job for the collection!!" -ForegroundColor Green
 }
 else
@@ -45,12 +48,12 @@ else
 }
 
 # Queue Collection workitem indexing job.
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem")
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
 {
     $Params = "CollectionId='$CollectionID'"
 
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueWorkItemExtensionInstallIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Successfully queued the WorkItem Indexing job for the collection!!" -ForegroundColor Green
 }
 else
@@ -59,12 +62,12 @@ else
 }
 
 # Queue Collection wiki indexing job.
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki")
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
 {
     $Params = "CollectionId='$CollectionID'"
 
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueWikiExtensionInstallIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Successfully queued the Wiki Indexing job for the collection!!" -ForegroundColor Green
 }
 else

--- a/Azure_DevOps_Server_2022/MissingIndexFolderTriggerCollectionIndexing.ps1
+++ b/Azure_DevOps_Server_2022/MissingIndexFolderTriggerCollectionIndexing.ps1
@@ -31,12 +31,12 @@ function CleanUpIndexingState
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
 CleanUpIndexingState
 
 # Queue Collection code indexing job.
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
 {
     $Params = "CollectionId='$CollectionID'"
 
@@ -50,7 +50,7 @@ else
 }
 
 # Queue Collection workitem indexing job.
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" @trustCertParam)
 {
     $Params = "CollectionId='$CollectionID'"
 
@@ -64,7 +64,7 @@ else
 }
 
 # Queue Collection wiki indexing job.
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" @trustCertParam)
 {
     $Params = "CollectionId='$CollectionID'"
 

--- a/Azure_DevOps_Server_2022/OptimizeElasticIndex.ps1
+++ b/Azure_DevOps_Server_2022/OptimizeElasticIndex.ps1
@@ -5,6 +5,10 @@ Param(
 
     [Parameter(Mandatory=$True, HelpMessage="Enter index name. Eg: code* for all code indices or a specific index name")]
     [string]$IndexName
+,
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 function OptimizeIndex

--- a/Azure_DevOps_Server_2022/OptimizeElasticIndex.ps1
+++ b/Azure_DevOps_Server_2022/OptimizeElasticIndex.ps1
@@ -4,8 +4,7 @@ Param(
     [string]$ElasticServerUrl,
 
     [Parameter(Mandatory=$True, HelpMessage="Enter index name. Eg: code* for all code indices or a specific index name")]
-    [string]$IndexName
-,
+    [string]$IndexName,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate

--- a/Azure_DevOps_Server_2022/OptimizeElasticIndex.ps1
+++ b/Azure_DevOps_Server_2022/OptimizeElasticIndex.ps1
@@ -4,10 +4,7 @@ Param(
     [string]$ElasticServerUrl,
 
     [Parameter(Mandatory=$True, HelpMessage="Enter index name. Eg: code* for all code indices or a specific index name")]
-    [string]$IndexName,
-
-    [Parameter(Mandatory=$False)]
-    [switch]$TrustServerCertificate
+    [string]$IndexName
 )
 
 function OptimizeIndex

--- a/Azure_DevOps_Server_2022/PauseIndexing.ps1
+++ b/Azure_DevOps_Server_2022/PauseIndexing.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True, Position=0, HelpMessage="The Server Instance against which the script is to run.")]
     [string]$SQLServerInstance,
@@ -8,6 +8,9 @@ Param(
     
     [Parameter(Mandatory=$False, Position=2, HelpMessage="Pause Indexing for Code, WorkItem, Wiki or All.")]
     [string]$EntityType = "All"
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 function ImportSQLModule
@@ -29,19 +32,19 @@ function ImportSQLModule
 function PauseCodeIndexing
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\PauseCodeIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 }
 
 function PauseWorkItemIndexing
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\PauseWorkItemIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 }
 
 function PauseWikiIndexing
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\PauseWikiIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 }
 
 Write-Host "This would pause indexing for all the collections. Do you want to continue - Yes or No? " -NoNewline -ForegroundColor Magenta

--- a/Azure_DevOps_Server_2022/PauseIndexing.ps1
+++ b/Azure_DevOps_Server_2022/PauseIndexing.ps1
@@ -7,7 +7,7 @@ Param(
     [string]$ConfigurationDatabaseName,
     
     [Parameter(Mandatory=$False, Position=2, HelpMessage="Pause Indexing for Code, WorkItem, Wiki or All.")]
-    [string]$EntityType = "All"
+    [string]$EntityType = "All",
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -31,20 +31,23 @@ function ImportSQLModule
 
 function PauseCodeIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\PauseCodeIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 }
 
 function PauseWorkItemIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\PauseWorkItemIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 }
 
 function PauseWikiIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\PauseWikiIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 }
 
 Write-Host "This would pause indexing for all the collections. Do you want to continue - Yes or No? " -NoNewline -ForegroundColor Magenta

--- a/Azure_DevOps_Server_2022/Re-IndexingCodeRepository.ps1
+++ b/Azure_DevOps_Server_2022/Re-IndexingCodeRepository.ps1
@@ -16,11 +16,12 @@ Param(
     [string]$CollectionName,
     
     [Parameter(Mandatory=$True, Position=5, HelpMessage="Update the tfvc/git repository name here.")]
-    [string]$RepositoryName
+    [string]$RepositoryName,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
 )
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
 Import-Module .\Common.psm1 -Force
 
@@ -34,12 +35,12 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 {
     $addDataParams = "IndexingUnitType='$IndexingUnitType'","CollectionId='$CollectionID'","RepositoryName='$RepositoryName'","RepositoryType='$IndexingUnitType'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddCodeRe-IndexingJobData.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $addDataParams -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $addDataParams @trustCertParam
     Write-Host "Added the job data as '$addDataParams'" -ForegroundColor Cyan
 
     $queueJobParams = "CollectionID='$CollectionID'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueCodeRe-IndexingJob.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $queueJobParams -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $queueJobParams @trustCertParam
     Write-Host "Successfully queued re-indexing job for the repository." -ForegroundColor Green
 }
 else

--- a/Azure_DevOps_Server_2022/Re-IndexingCodeRepository.ps1
+++ b/Azure_DevOps_Server_2022/Re-IndexingCodeRepository.ps1
@@ -29,9 +29,9 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
 {
     $addDataParams = "IndexingUnitType='$IndexingUnitType'","CollectionId='$CollectionID'","RepositoryName='$RepositoryName'","RepositoryType='$IndexingUnitType'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddCodeRe-IndexingJobData.sql'

--- a/Azure_DevOps_Server_2022/Re-IndexingCodeRepository.ps1
+++ b/Azure_DevOps_Server_2022/Re-IndexingCodeRepository.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True, Position=0, HelpMessage="The Server Instance against which the script is to run.")]
     [string]$SQLServerInstance,
@@ -17,6 +17,9 @@ Param(
     
     [Parameter(Mandatory=$True, Position=5, HelpMessage="Update the tfvc/git repository name here.")]
     [string]$RepositoryName
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 Import-Module .\Common.psm1 -Force
@@ -25,18 +28,18 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
 {
     $addDataParams = "IndexingUnitType='$IndexingUnitType'","CollectionId='$CollectionID'","RepositoryName='$RepositoryName'","RepositoryType='$IndexingUnitType'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddCodeRe-IndexingJobData.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $addDataParams
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $addDataParams -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Added the job data as '$addDataParams'" -ForegroundColor Cyan
 
     $queueJobParams = "CollectionID='$CollectionID'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueueCodeRe-IndexingJob.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $queueJobParams
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $queueJobParams -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Successfully queued re-indexing job for the repository." -ForegroundColor Green
 }
 else

--- a/Azure_DevOps_Server_2022/ReIndexFiles.ps1
+++ b/Azure_DevOps_Server_2022/ReIndexFiles.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 This script configures a path of a repository for re-indexing.
 #>
 
@@ -24,6 +24,9 @@ Param(
 
     [Parameter(Mandatory=$True, Position=6, HelpMessage="File/Folder which has to be re-indexed.")]
     [string]$Path
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 IF ([string]::IsNullOrWhiteSpace($SQLServerInstance) -Or 
@@ -58,13 +61,13 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
 {
     $AddFilesParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","Path='$Path'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddFilesToBeIndexed.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $AddFilesParams
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $AddFilesParams -TrustServerCertificate:$TrustServerCertificate
     
     if ($queryResults)
     {
@@ -74,7 +77,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 
         $QueueMaintenanceJobParams = "CollectionId='$CollectionID'"
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueuePeriodicMaintenanceJob.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams
+        Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams -TrustServerCertificate:$TrustServerCertificate
 
         Write-Host "Configured path '$Path' of Repository '$RepositoryName' in Collection '$CollectionName' for re-indexing." -ForegroundColor Green
     }

--- a/Azure_DevOps_Server_2022/ReIndexFiles.ps1
+++ b/Azure_DevOps_Server_2022/ReIndexFiles.ps1
@@ -23,11 +23,12 @@ Param(
     [string]$RepositoryName,
 
     [Parameter(Mandatory=$True, Position=6, HelpMessage="File/Folder which has to be re-indexed.")]
-    [string]$Path
+    [string]$Path,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
 )
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
 IF ([string]::IsNullOrWhiteSpace($SQLServerInstance) -Or 
     [string]::IsNullOrWhiteSpace($CollectionDatabaseName) -Or 
@@ -67,7 +68,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 {
     $AddFilesParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","Path='$Path'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddFilesToBeIndexed.sql'
-    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $AddFilesParams -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $AddFilesParams @trustCertParam
     
     if ($queryResults)
     {
@@ -77,7 +78,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 
         $QueueMaintenanceJobParams = "CollectionId='$CollectionID'"
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueuePeriodicMaintenanceJob.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams @trustCertParam
 
         Write-Host "Configured path '$Path' of Repository '$RepositoryName' in Collection '$CollectionName' for re-indexing." -ForegroundColor Green
     }

--- a/Azure_DevOps_Server_2022/ReIndexFiles.ps1
+++ b/Azure_DevOps_Server_2022/ReIndexFiles.ps1
@@ -62,9 +62,9 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
 {
     $AddFilesParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","Path='$Path'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddFilesToBeIndexed.sql'

--- a/Azure_DevOps_Server_2022/RecentIndexingActivity.ps1
+++ b/Azure_DevOps_Server_2022/RecentIndexingActivity.ps1
@@ -27,7 +27,7 @@ function CodeIndexingActivity
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     Write-Host "Code Indexing Stats:" -ForegroundColor Green
 
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
     {
         $Params = "CollectionId='$CollectionID'" 
         $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"
@@ -114,7 +114,7 @@ function WorkItemIndexingActivity
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     Write-Host "WorkItem Indexing Stats:" -ForegroundColor Green
 
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" @trustCertParam)
     {
         $Params = "CollectionId='$CollectionID'" 
         $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"
@@ -201,7 +201,7 @@ function WikiIndexingActivity
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     Write-Host "Wiki Indexing Stats:" -ForegroundColor Green
 
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" @trustCertParam)
     {
         $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"
 
@@ -260,7 +260,8 @@ Write-Host "Checking indexing state for last $Days days" -ForegroundColor Green
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 switch ($EntityType)
 {
     "All" 

--- a/Azure_DevOps_Server_2022/RecentIndexingActivity.ps1
+++ b/Azure_DevOps_Server_2022/RecentIndexingActivity.ps1
@@ -17,20 +17,23 @@ Param(
     
     [Parameter(Mandatory=$False, Position=5, HelpMessage="Trigger collection indexing for Code, WorkItem, Wiki or All")]
     [string]$EntityType = "All"
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 function CodeIndexingActivity
 {
     Write-Host "Code Indexing Stats:" -ForegroundColor Green
 
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'" 
         $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"
 
         # Gets the count of code repositories for which fresh indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeBulkIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $bulkIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingCompletedCount
 
         if($bulkIndexingCompletedRepositoryCount -gt 0)
@@ -44,7 +47,7 @@ function CodeIndexingActivity
 
         # Gets the count of repositories for which fresh indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeBulkIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
         $bulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingInProgressCount
 
         if($bulkIndexingInProgressRepositoryCount -gt 0)
@@ -59,7 +62,7 @@ function CodeIndexingActivity
 
          # Gets the count of repositories for which continuous indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeContinuousIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $continuousIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingCompletedCount
 
         if($continuousIndexingCompletedRepositoryCount -gt 0)
@@ -73,7 +76,7 @@ function CodeIndexingActivity
 
         # Gets the count of repositories for which continuous indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeContinuousIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
         $continuousIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingInProgressCount
 
         if($continuousIndexingInProgressRepositoryCount -gt 0)
@@ -87,7 +90,7 @@ function CodeIndexingActivity
 
         # Gets the count of Failed Indexing jobs.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeFailedIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $failedIndexingJobsCount = $queryResults  | Select-object  -ExpandProperty  FailedIndexingCount
 
         if($failedIndexingJobsCount -gt 0)
@@ -109,14 +112,14 @@ function WorkItemIndexingActivity
 {
     Write-Host "WorkItem Indexing Stats:" -ForegroundColor Green
 
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'" 
         $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"
 
         # Gets the count of code repositories for which fresh indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemBulkIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $bulkIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingCompletedCount
 
         if($bulkIndexingCompletedRepositoryCount -gt 0)
@@ -130,7 +133,7 @@ function WorkItemIndexingActivity
 
         # Gets the count of repositories for which fresh indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemBulkIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
         $bulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingInProgressCount
 
         if($bulkIndexingInProgressRepositoryCount -gt 0)
@@ -145,7 +148,7 @@ function WorkItemIndexingActivity
 
          # Gets the count of repositories for which continuous indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemContinuousIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $continuousIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingCompletedCount
 
         if($continuousIndexingCompletedRepositoryCount -gt 0)
@@ -159,7 +162,7 @@ function WorkItemIndexingActivity
 
         # Gets the count of repositories for which continuous indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemContinuousIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
         $continuousIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingInProgressCount
 
         if($continuousIndexingInProgressRepositoryCount -gt 0)
@@ -173,7 +176,7 @@ function WorkItemIndexingActivity
 
         # Gets the count of Failed Indexing jobs.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemFailedIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $failedIndexingJobsCount = $queryResults  | Select-object  -ExpandProperty  FailedIndexingCount
 
         if($failedIndexingJobsCount -gt 0)
@@ -195,13 +198,13 @@ function WikiIndexingActivity
 {
     Write-Host "Wiki Indexing Stats:" -ForegroundColor Green
 
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
     {
         $indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"
 
         # Gets the count of wiki repositories for which fresh indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingCompletedActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $bulkIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
         if($bulkIndexingCompletedRepositoryCount -gt 0)
@@ -215,7 +218,7 @@ function WikiIndexingActivity
 
         # Gets the count of repositories for which fresh indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $bulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingInProgressCount
 
         if($bulkIndexingInProgressRepositoryCount -gt 0)
@@ -229,7 +232,7 @@ function WikiIndexingActivity
 
         # Gets the count of Failed Indexing operations.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiFailedIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
         $failedIndexingOperationsCount = $queryResults  | Select-object  -ExpandProperty  FailedIndexingCount
 
         if($failedIndexingOperationsCount -gt 0)
@@ -254,7 +257,7 @@ Write-Host "Checking indexing state for last $Days days" -ForegroundColor Green
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 switch ($EntityType)
 {
     "All" 

--- a/Azure_DevOps_Server_2022/RecentIndexingActivity.ps1
+++ b/Azure_DevOps_Server_2022/RecentIndexingActivity.ps1
@@ -16,7 +16,7 @@ Param(
     [string]$Days,
     
     [Parameter(Mandatory=$False, Position=5, HelpMessage="Trigger collection indexing for Code, WorkItem, Wiki or All")]
-    [string]$EntityType = "All"
+    [string]$EntityType = "All",
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -24,6 +24,7 @@ Param(
 
 function CodeIndexingActivity
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     Write-Host "Code Indexing Stats:" -ForegroundColor Green
 
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
@@ -33,7 +34,7 @@ function CodeIndexingActivity
 
         # Gets the count of code repositories for which fresh indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeBulkIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $bulkIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingCompletedCount
 
         if($bulkIndexingCompletedRepositoryCount -gt 0)
@@ -47,7 +48,7 @@ function CodeIndexingActivity
 
         # Gets the count of repositories for which fresh indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeBulkIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
         $bulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingInProgressCount
 
         if($bulkIndexingInProgressRepositoryCount -gt 0)
@@ -62,7 +63,7 @@ function CodeIndexingActivity
 
          # Gets the count of repositories for which continuous indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeContinuousIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $continuousIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingCompletedCount
 
         if($continuousIndexingCompletedRepositoryCount -gt 0)
@@ -76,7 +77,7 @@ function CodeIndexingActivity
 
         # Gets the count of repositories for which continuous indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeContinuousIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
         $continuousIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingInProgressCount
 
         if($continuousIndexingInProgressRepositoryCount -gt 0)
@@ -90,7 +91,7 @@ function CodeIndexingActivity
 
         # Gets the count of Failed Indexing jobs.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeFailedIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $failedIndexingJobsCount = $queryResults  | Select-object  -ExpandProperty  FailedIndexingCount
 
         if($failedIndexingJobsCount -gt 0)
@@ -110,6 +111,7 @@ function CodeIndexingActivity
 
 function WorkItemIndexingActivity
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     Write-Host "WorkItem Indexing Stats:" -ForegroundColor Green
 
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
@@ -119,7 +121,7 @@ function WorkItemIndexingActivity
 
         # Gets the count of code repositories for which fresh indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemBulkIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $bulkIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingCompletedCount
 
         if($bulkIndexingCompletedRepositoryCount -gt 0)
@@ -133,7 +135,7 @@ function WorkItemIndexingActivity
 
         # Gets the count of repositories for which fresh indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemBulkIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
         $bulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  BulkIndexingInProgressCount
 
         if($bulkIndexingInProgressRepositoryCount -gt 0)
@@ -148,7 +150,7 @@ function WorkItemIndexingActivity
 
          # Gets the count of repositories for which continuous indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemContinuousIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $continuousIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingCompletedCount
 
         if($continuousIndexingCompletedRepositoryCount -gt 0)
@@ -162,7 +164,7 @@ function WorkItemIndexingActivity
 
         # Gets the count of repositories for which continuous indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemContinuousIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
         $continuousIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ContinuousIndexingInProgressCount
 
         if($continuousIndexingInProgressRepositoryCount -gt 0)
@@ -176,7 +178,7 @@ function WorkItemIndexingActivity
 
         # Gets the count of Failed Indexing jobs.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemFailedIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $failedIndexingJobsCount = $queryResults  | Select-object  -ExpandProperty  FailedIndexingCount
 
         if($failedIndexingJobsCount -gt 0)
@@ -196,6 +198,7 @@ function WorkItemIndexingActivity
 
 function WikiIndexingActivity
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     Write-Host "Wiki Indexing Stats:" -ForegroundColor Green
 
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
@@ -204,7 +207,7 @@ function WikiIndexingActivity
 
         # Gets the count of wiki repositories for which fresh indexing has completed.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingCompletedActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $bulkIndexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
 
         if($bulkIndexingCompletedRepositoryCount -gt 0)
@@ -218,7 +221,7 @@ function WikiIndexingActivity
 
         # Gets the count of repositories for which fresh indexing is InProgress.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingInProgressActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $bulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingInProgressCount
 
         if($bulkIndexingInProgressRepositoryCount -gt 0)
@@ -232,7 +235,7 @@ function WikiIndexingActivity
 
         # Gets the count of Failed Indexing operations.
         $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiFailedIndexingActivity.sql'
-        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams -TrustServerCertificate:$TrustServerCertificate
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams @trustCertParam
         $failedIndexingOperationsCount = $queryResults  | Select-object  -ExpandProperty  FailedIndexingCount
 
         if($failedIndexingOperationsCount -gt 0)

--- a/Azure_DevOps_Server_2022/ResumeIndexing.ps1
+++ b/Azure_DevOps_Server_2022/ResumeIndexing.ps1
@@ -7,7 +7,7 @@ Param(
     [string]$ConfigurationDatabaseName,
     
     [Parameter(Mandatory=$False, Position=2, HelpMessage="Resume Indexing for Code, WorkItem, Wiki or All")]
-    [string]$EntityType = "All"
+    [string]$EntityType = "All",
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -15,22 +15,25 @@ Param(
 
 function ResumeCodeIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\ResumeCodeIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
     Write-Host "Code Indexing has been resumed!!" -ForegroundColor Green
 }
 
 function ResumeWorkItemIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\ResumeWorkItemIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
     Write-Host "WorkItem Indexing has been resumed!!" -ForegroundColor Green
 }
 
 function ResumeWikiIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\ResumeWikiIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
     Write-Host "Wiki Indexing has been resumed!!" -ForegroundColor Green
 }
 

--- a/Azure_DevOps_Server_2022/ResumeIndexing.ps1
+++ b/Azure_DevOps_Server_2022/ResumeIndexing.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True, Position=0, HelpMessage="The Server Instance against which the script is to run.")]
     [string]$SQLServerInstance,
@@ -8,26 +8,29 @@ Param(
     
     [Parameter(Mandatory=$False, Position=2, HelpMessage="Resume Indexing for Code, WorkItem, Wiki or All")]
     [string]$EntityType = "All"
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 function ResumeCodeIndexing
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\ResumeCodeIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Code Indexing has been resumed!!" -ForegroundColor Green
 }
 
 function ResumeWorkItemIndexing
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\ResumeWorkItemIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
     Write-Host "WorkItem Indexing has been resumed!!" -ForegroundColor Green
 }
 
 function ResumeWikiIndexing
 {
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\ResumeWikiIndexing.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
     Write-Host "Wiki Indexing has been resumed!!" -ForegroundColor Green
 }
 

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/CollectionDBSearchDiagnostics.ps1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/CollectionDBSearchDiagnostics.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True, Position=0, HelpMessage="The SQL Server Instance against which the script is to run.")]
     [string]$SQLServerInstance,
@@ -11,6 +11,9 @@ Param(
    
     [Parameter(Mandatory=$True, Position=3, HelpMessage="Collection Name")]
     [string]$CollectionName
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 function CollectionDBSearchStatus
@@ -28,7 +31,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $IndexingUnitLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\IndexingUnitData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -44,7 +47,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $IndexingUnitChangeEventLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\IndexingUnitChangeEventData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -60,7 +63,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $ItemLevelFailuresLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\ItemLevelFailuresData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -76,7 +79,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $JobYieldLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\JobYieldData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -92,7 +95,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $ResourceLockLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\ResourceLockData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -108,7 +111,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $DisabledFilesLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\DisabledFilesData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -124,7 +127,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $SearchRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\SearchRegistryDataOfCollection.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -140,7 +143,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $ClassificationNodeLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\ClassificationNodeData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -163,7 +166,7 @@ Write-Host "Extracting Search diagnostics data from '$CollectionDatabaseName' da
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
 CollectionDBSearchStatus
 

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/CollectionDBSearchDiagnostics.ps1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/CollectionDBSearchDiagnostics.ps1
@@ -167,7 +167,8 @@ Write-Host "Extracting Search diagnostics data from '$CollectionDatabaseName' da
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
 CollectionDBSearchStatus
 

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/CollectionDBSearchDiagnostics.ps1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/CollectionDBSearchDiagnostics.ps1
@@ -10,7 +10,7 @@ Param(
     [string]$ConfigurationDatabaseName,
    
     [Parameter(Mandatory=$True, Position=3, HelpMessage="Collection Name")]
-    [string]$CollectionName
+    [string]$CollectionName,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -18,6 +18,7 @@ Param(
 
 function CollectionDBSearchStatus
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 	Write-Host "CollectionId = $CollectionID" -ForegroundColor Green
 	
 	$collectionLogDir = Join-Path $PWD -ChildPath "CollectionDBDiagnosticScripts\$CollectionName"
@@ -31,7 +32,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $IndexingUnitLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\IndexingUnitData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -47,7 +48,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $IndexingUnitChangeEventLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\IndexingUnitChangeEventData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -63,7 +64,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $ItemLevelFailuresLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\ItemLevelFailuresData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -79,7 +80,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $JobYieldLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\JobYieldData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -95,7 +96,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $ResourceLockLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\ResourceLockData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -111,7 +112,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $DisabledFilesLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\DisabledFilesData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -127,7 +128,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $SearchRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\SearchRegistryDataOfCollection.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -143,7 +144,7 @@ function CollectionDBSearchStatus
 	Set-Content -Path $ClassificationNodeLogPath ([Environment]::NewLine)
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'CollectionDBDiagnosticScripts\ClassificationNodeData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
@@ -39,8 +39,9 @@ function ValidateCollectionName
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
-    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName'" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName'" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose @trustCertParam
 
     $CollectionID = $queryResults  | Select-object  -ExpandProperty  HOSTID
 
@@ -65,10 +66,11 @@ function IsExtensionInstalled
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     return $true
 
-    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam
     
     if($isCollectionIndexed.RegValue -eq "True")
     {

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
@@ -1,4 +1,4 @@
-﻿function ImportSQLModule
+function ImportSQLModule
 {
     $moduleCheck = Get-Module -List SQLSERVER
     if($moduleCheck)
@@ -35,9 +35,12 @@ function ValidateCollectionName
         [string] $SQLServerInstance,
         [string] $ConfigurationDatabaseName,
         [string] $CollectionName
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
-    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName'" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose 
+    $queryResults = Invoke-Sqlcmd -Query "Select HostID from [dbo].[tbl_ServiceHost] where Name = '$CollectionName'" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -TrustServerCertificate:$TrustServerCertificate
 
     $CollectionID = $queryResults  | Select-object  -ExpandProperty  HOSTID
 
@@ -58,11 +61,14 @@ function IsExtensionInstalled
         [string] $SQLServerInstance,
         [string] $CollectionDatabaseName,
         [string] $RegValue
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     return $true
 
-    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName
+    $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
     
     if($isCollectionIndexed.RegValue -eq "True")
     {

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
@@ -34,8 +34,7 @@ function ValidateCollectionName
     (
         [string] $SQLServerInstance,
         [string] $ConfigurationDatabaseName,
-        [string] $CollectionName
-
+        [string] $CollectionName,
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/Common.psm1
@@ -61,14 +61,11 @@ function IsExtensionInstalled
     (
         [string] $SQLServerInstance,
         [string] $CollectionDatabaseName,
-        [string] $RegValue
-
+        [string] $RegValue,
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
-
-    return $true
 
     $isCollectionIndexed = Invoke-Sqlcmd -Query "Select RegValue from tbl_RegistryItems where ChildItem like '%$RegValue%' and PartitionId > 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam
     

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/ConfigurationDBSearchDiagnostics.ps1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/ConfigurationDBSearchDiagnostics.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True, Position=0, HelpMessage="The SQL Server Instance against which the script is to run.")]
     [string]$SQLServerInstance,
@@ -8,6 +8,9 @@ Param(
 	     
     [Parameter(Mandatory=$True, Position=2, HelpMessage="Enter the number of days since when the tbl_JobHistory data needs to be fetched")]
     [string]$Days
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 function ConfigurationDBSearchStatus
@@ -22,7 +25,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $ServiceHostLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\ServiceHostData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -38,7 +41,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $SearchConnectionUrlRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\SearchConnectionUrlData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -54,7 +57,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $JobThrottlingRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\JobThrottlingData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -70,7 +73,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $SearchRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\SearchRegistryData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -86,7 +89,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $JobQueueLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\JobQueueData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{
@@ -104,7 +107,7 @@ function ConfigurationDBSearchStatus
 	$jobHistoryQueryParams = "DaysAgo='$Days'"
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\JobHistoryData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $jobHistoryQueryParams
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $jobHistoryQueryParams -TrustServerCertificate:$TrustServerCertificate
 	
 	foreach($row in $queryResults)
 	{

--- a/Azure_DevOps_Server_2022/SearchDiagonistics/ConfigurationDBSearchDiagnostics.ps1
+++ b/Azure_DevOps_Server_2022/SearchDiagonistics/ConfigurationDBSearchDiagnostics.ps1
@@ -7,7 +7,7 @@ Param(
     [string]$ConfigurationDatabaseName,
 	     
     [Parameter(Mandatory=$True, Position=2, HelpMessage="Enter the number of days since when the tbl_JobHistory data needs to be fetched")]
-    [string]$Days
+    [string]$Days,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
@@ -15,6 +15,7 @@ Param(
 
 function ConfigurationDBSearchStatus
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 	$configLogDir = Join-Path $PWD -ChildPath 'ConfigurationDBDiagonistics'
 	New-Item -ItemType Directory -Force -Path $configLogDir
 	
@@ -25,7 +26,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $ServiceHostLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\ServiceHostData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -41,7 +42,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $SearchConnectionUrlRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\SearchConnectionUrlData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -57,7 +58,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $JobThrottlingRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\JobThrottlingData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -73,7 +74,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $SearchRegistryLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\SearchRegistryData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -89,7 +90,7 @@ function ConfigurationDBSearchStatus
 	Set-Content -Path $JobQueueLogPath ([Environment]::NewLine)
 	
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\JobQueueData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName @trustCertParam
 	
 	foreach($row in $queryResults)
 	{
@@ -107,7 +108,7 @@ function ConfigurationDBSearchStatus
 	$jobHistoryQueryParams = "DaysAgo='$Days'"
 
 	$SqlFullPath = Join-Path $PWD -ChildPath 'ConfigurationDBDiagnosticScripts\JobHistoryData.sql'
-	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $jobHistoryQueryParams -TrustServerCertificate:$TrustServerCertificate
+	$queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $jobHistoryQueryParams @trustCertParam
 	
 	foreach($row in $queryResults)
 	{

--- a/Azure_DevOps_Server_2022/SetIndexingStateRepository.ps1
+++ b/Azure_DevOps_Server_2022/SetIndexingStateRepository.ps1
@@ -45,9 +45,9 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
 {
     $IndexingStateParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","IndexingState='$IndexingState'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddRepositoryUpdateMetadataChangeEvent.sql'

--- a/Azure_DevOps_Server_2022/SetIndexingStateRepository.ps1
+++ b/Azure_DevOps_Server_2022/SetIndexingStateRepository.ps1
@@ -23,11 +23,12 @@ Param(
     [string]$RepositoryName,
 
     [Parameter(Mandatory=$True, Position=6, HelpMessage="Set the Indexing State here.")]
-    [string]$IndexingState
+    [string]$IndexingState,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
 )
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
 if ([string]::IsNullOrWhiteSpace($SQLServerInstance) -Or [string]::IsNullOrWhiteSpace($CollectionDatabaseName) -Or [string]::IsNullOrWhiteSpace($ConfigurationDatabaseName) -Or [string]::IsNullOrWhiteSpace($CollectionName) -Or [string]::IsNullOrWhiteSpace($ProjectName) -Or [string]::IsNullOrWhiteSpace($RepositoryName)) {
     Throw "None of the values supplied can be null or empty. Please retry"
@@ -50,7 +51,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 {
     $IndexingStateParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","IndexingState='$IndexingState'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddRepositoryUpdateMetadataChangeEvent.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $IndexingStateParams -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $IndexingStateParams @trustCertParam
 
     <#
         Let's queue the maintenance job now so that the event added above is processed immediately. Otherwise, it would wait for the next check-in/periodic job run to get processed.
@@ -58,7 +59,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 
     $QueueMaintenanceJobParams = "CollectionId='$CollectionID'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueuePeriodicMaintenanceJob.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams -TrustServerCertificate:$TrustServerCertificate
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams @trustCertParam
 
     Write-Host "Marked state of Repository '$RepositoryName' in Collection '$CollectionName' to '$IndexingState'" -ForegroundColor Cyan
 }

--- a/Azure_DevOps_Server_2022/SetIndexingStateRepository.ps1
+++ b/Azure_DevOps_Server_2022/SetIndexingStateRepository.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 This script sets the indexing state of the given repository to On or Off.
 #>
 
@@ -24,6 +24,9 @@ Param(
 
     [Parameter(Mandatory=$True, Position=6, HelpMessage="Set the Indexing State here.")]
     [string]$IndexingState
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 if ([string]::IsNullOrWhiteSpace($SQLServerInstance) -Or [string]::IsNullOrWhiteSpace($CollectionDatabaseName) -Or [string]::IsNullOrWhiteSpace($ConfigurationDatabaseName) -Or [string]::IsNullOrWhiteSpace($CollectionName) -Or [string]::IsNullOrWhiteSpace($ProjectName) -Or [string]::IsNullOrWhiteSpace($RepositoryName)) {
@@ -41,13 +44,13 @@ Import-Module .\Common.psm1 -Force
 Push-Location
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
-if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
 {
     $IndexingStateParams = "CollectionId='$CollectionID'","ProjectName='$ProjectName'","RepositoryName='$RepositoryName'","IndexingState='$IndexingState'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\AddRepositoryUpdateMetadataChangeEvent.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $IndexingStateParams
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $IndexingStateParams -TrustServerCertificate:$TrustServerCertificate
 
     <#
         Let's queue the maintenance job now so that the event added above is processed immediately. Otherwise, it would wait for the next check-in/periodic job run to get processed.
@@ -55,7 +58,7 @@ if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollection
 
     $QueueMaintenanceJobParams = "CollectionId='$CollectionID'"
     $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\QueuePeriodicMaintenanceJob.sql'
-    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $QueueMaintenanceJobParams -TrustServerCertificate:$TrustServerCertificate
 
     Write-Host "Marked state of Repository '$RepositoryName' in Collection '$CollectionName' to '$IndexingState'" -ForegroundColor Cyan
 }

--- a/Azure_DevOps_Server_2022/TriggerCollectionIndexing.ps1
+++ b/Azure_DevOps_Server_2022/TriggerCollectionIndexing.ps1
@@ -15,22 +15,25 @@ Param
     
     [Parameter(Mandatory=$True, Position=4, HelpMessage="Trigger collection indexing for Code, WorkItem, Wiki or All")]
     [ValidateSet("All", "Code", "WorkItem", "Wiki")]
-    [string]$EntityType
+    [string]$EntityType,
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 Import-Module "$PSScriptRoot\Common.psm1" -Force
 
 function TriggerCodeIndexing
 {
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='Code'", "EntityTypeInt=1"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
         Write-Host "Cleaned up the Code Collection Indexing state." -ForegroundColor Yellow
 
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\QueueCodeExtensionInstallIndexing.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
         Write-Host "Successfully queued the code Indexing job for the collection!!" -ForegroundColor Green
     }
     else
@@ -41,15 +44,15 @@ function TriggerCodeIndexing
 
 function TriggerWorkItemIndexing
 {
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='WorkItem'", "EntityTypeInt=4"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
         Write-Host "Cleaned up the WorkItem Collection Indexing state." -ForegroundColor Yellow
 
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\QueueWorkItemExtensionInstallIndexing.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
         Write-Host "Successfully queued the WorkItem Indexing job for the collection!!" -ForegroundColor Green
     }
     else
@@ -60,15 +63,15 @@ function TriggerWorkItemIndexing
 
 function TriggerWikiIndexing
 {
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki")
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='Wiki'", "EntityTypeInt=6"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
         Write-Host "Cleaned up the Wiki Collection Indexing state." -ForegroundColor Yellow
 
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\QueueWikiExtensionInstallIndexing.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
         Write-Host "Successfully queued the Wiki Indexing job for the collection!!" -ForegroundColor Green
     }
     else
@@ -79,7 +82,7 @@ function TriggerWikiIndexing
 
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
 switch ($EntityType)
 {

--- a/Azure_DevOps_Server_2022/TriggerCollectionIndexing.ps1
+++ b/Azure_DevOps_Server_2022/TriggerCollectionIndexing.ps1
@@ -25,15 +25,16 @@ Import-Module "$PSScriptRoot\Common.psm1" -Force
 
 function TriggerCodeIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='Code'", "EntityTypeInt=1"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params @trustCertParam
         Write-Host "Cleaned up the Code Collection Indexing state." -ForegroundColor Yellow
 
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\QueueCodeExtensionInstallIndexing.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
         Write-Host "Successfully queued the code Indexing job for the collection!!" -ForegroundColor Green
     }
     else
@@ -44,15 +45,16 @@ function TriggerCodeIndexing
 
 function TriggerWorkItemIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='WorkItem'", "EntityTypeInt=4"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params @trustCertParam
         Write-Host "Cleaned up the WorkItem Collection Indexing state." -ForegroundColor Yellow
 
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\QueueWorkItemExtensionInstallIndexing.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
         Write-Host "Successfully queued the WorkItem Indexing job for the collection!!" -ForegroundColor Green
     }
     else
@@ -63,15 +65,16 @@ function TriggerWorkItemIndexing
 
 function TriggerWikiIndexing
 {
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='Wiki'", "EntityTypeInt=6"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $Params @trustCertParam
         Write-Host "Cleaned up the Wiki Collection Indexing state." -ForegroundColor Yellow
 
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\QueueWikiExtensionInstallIndexing.sql'
-        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params @trustCertParam
         Write-Host "Successfully queued the Wiki Indexing job for the collection!!" -ForegroundColor Green
     }
     else

--- a/Azure_DevOps_Server_2022/TriggerCollectionIndexing.ps1
+++ b/Azure_DevOps_Server_2022/TriggerCollectionIndexing.ps1
@@ -26,7 +26,7 @@ Import-Module "$PSScriptRoot\Common.psm1" -Force
 function TriggerCodeIndexing
 {
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed" @trustCertParam)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='Code'", "EntityTypeInt=1"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
@@ -46,7 +46,7 @@ function TriggerCodeIndexing
 function TriggerWorkItemIndexing
 {
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem" @trustCertParam)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='WorkItem'", "EntityTypeInt=4"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
@@ -66,7 +66,7 @@ function TriggerWorkItemIndexing
 function TriggerWikiIndexing
 {
     $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
-    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate)
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki" @trustCertParam)
     {
         $Params = "CollectionId='$CollectionID'", "EntityTypeString='Wiki'", "EntityTypeInt=6"
         $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\CleanUpCollectionIndexingState.sql'
@@ -85,7 +85,8 @@ function TriggerWikiIndexing
 
 ImportSQLModule
 
-$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName -TrustServerCertificate:$TrustServerCertificate
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName @trustCertParam
 
 switch ($EntityType)
 {

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Enable-IndexingFeatureFlags.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Enable-IndexingFeatureFlags.psm1
@@ -29,6 +29,9 @@ function Enable-IndexingFeatureFlags
         
         [Parameter(Mandatory=$False)]
         [string] $AdditionalParam
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     $message = "Enable indexing of [$EntityType] in collection [$CollectionName]"
@@ -39,28 +42,28 @@ function Enable-IndexingFeatureFlags
         {
             "Code"
             {
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Code.Indexing" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.Indexing" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Code.CrudOperations" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.CrudOperations" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Code.Indexing" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.Indexing" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Code.CrudOperations" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.CrudOperations" -State On -TrustServerCertificate:$TrustServerCertificate
                 break
             }
 
             "WorkItem"
             {
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.WorkItem.Indexing" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.Indexing" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.WorkItem.CrudOperations" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.CrudOperations" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.WorkItem.Indexing" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.Indexing" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.WorkItem.CrudOperations" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.CrudOperations" -State On -TrustServerCertificate:$TrustServerCertificate
                 break
             }
 
             "Wiki"
             {
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Wiki.Indexing" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.Indexing" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State On
-                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Wiki.Indexing" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.Indexing" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State On -TrustServerCertificate:$TrustServerCertificate
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State On -TrustServerCertificate:$TrustServerCertificate
                 break
             }
 

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Enable-IndexingFeatureFlags.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Enable-IndexingFeatureFlags.psm1
@@ -28,7 +28,7 @@ function Enable-IndexingFeatureFlags
         [string] $EntityType,
         
         [Parameter(Mandatory=$False)]
-        [string] $AdditionalParam
+        [string] $AdditionalParam,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
@@ -33,11 +33,12 @@ function Remove-OrphanIndexedDocuments
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     # Get collection Id, index name and mapping name from collection indexing unit
     $sqlQueryProperties = "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\GetCollectionIndexingUnitDetails.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties @trustCertParam
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
@@ -28,7 +28,7 @@ function Remove-OrphanIndexedDocuments
         [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
-        [string] $AdditionalParam
+        [string] $AdditionalParam,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
@@ -29,12 +29,15 @@ function Remove-OrphanIndexedDocuments
 
         [Parameter(Mandatory=$False)]
         [string] $AdditionalParam
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     # Get collection Id, index name and mapping name from collection indexing unit
     $sqlQueryProperties = "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\GetCollectionIndexingUnitDetails.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties -TrustServerCertificate:$TrustServerCertificate
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Reset-ExtensionInstallationRegKeys.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Reset-ExtensionInstallationRegKeys.psm1
@@ -29,9 +29,12 @@ function Reset-ExtensionInstallationRegKeys
         
         [Parameter(Mandatory=$False)]
         [string] $AdditionalParam
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     $regKey = "\Service\ALMSearch\Settings\IsExtensionOperationInProgress\$EntityType\Uninstalled"
-    Set-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -RegistryPath $regKey -Value $null
+    Set-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -RegistryPath $regKey -Value $null -TrustServerCertificate:$TrustServerCertificate
     Write-Log "Removed registry [$regKey] from [$CollectionDatabaseName] database."
 }

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Restart-Indexing.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Restart-Indexing.psm1
@@ -70,7 +70,7 @@ function Restart-Indexing
         -CollectionDatabaseName $CollectionDatabaseName `
         -CollectionName $CollectionName `
         -EntityType $EntityType `
-            -TrustServerCertificate:$TrustServerCertificate
+        -TrustServerCertificate:$TrustServerCertificate
 
     # Reset data from SQL
     $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
@@ -137,7 +137,7 @@ function Restart-Indexing
         -WhatIf:$False `
         -Confirm:$False `
         -Verbose:$VerbosePreference `
-            -TrustServerCertificate:$TrustServerCertificate
+        -TrustServerCertificate:$TrustServerCertificate
 
     # Queue fault-in job if not queued already
     if (!(Test-BulkIndexingIsInProgress `
@@ -154,7 +154,7 @@ function Restart-Indexing
             -CollectionDatabaseName $CollectionDatabaseName `
             -CollectionName $CollectionName `
             -EntityType $EntityType `
-                -TrustServerCertificate:$TrustServerCertificate
+            -TrustServerCertificate:$TrustServerCertificate
     }
     else
     {

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Restart-Indexing.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Restart-Indexing.psm1
@@ -33,6 +33,7 @@ function Restart-Indexing
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     # Reset uninstall in progress related registry keys
     Reset-ExtensionInstallationRegKeys `
@@ -75,7 +76,7 @@ function Restart-Indexing
     $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     $sqlParams = "CollectionId='$collectionId'", "EntityTypeString='$EntityType'", "EntityTypeInt=$(Get-EntityTypeId $EntityType)"
     $sqlFilePath = "$PSScriptRoot\..\SqlScripts\CleanUpCollectionIndexingState.sql"
-    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlParams -TrustServerCertificate:$TrustServerCertificate
+    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlParams @trustCertParam
     Write-Log "Cleaned up all SQL tables storing indexing state."
 
     # Delete data indexed in Elasticsearch
@@ -99,7 +100,7 @@ function Restart-Indexing
     }
 
     # Get all Job Ids corresponding to all indexing units of the given entity type
- $indexingJobIds = Invoke-Sqlcmd -Query "SELECT AssociatedJobId FROM Search.tbl_IndexingUnit WHERE EntityType = '$EntityType' AND AssociatedJobId IS NOT NULL AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty AssociatedJobId
+ $indexingJobIds = Invoke-Sqlcmd -Query "SELECT AssociatedJobId FROM Search.tbl_IndexingUnit WHERE EntityType = '$EntityType' AND AssociatedJobId IS NOT NULL AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty AssociatedJobId
     if ($indexingJobIds)
     {
         $timeoutInMinutes = 15
@@ -107,7 +108,7 @@ function Restart-Indexing
         $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         while ($stopwatch.Elapsed.TotalMinutes -lt $timeoutInMinutes) # Waiting for a maximum of $timeoutInMinutes minutes
         {
- $indexingJobQueuedCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) As IndexingJobQueuedCount FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId IN ($(($indexingJobIds | ForEach-Object { "'$_'" }) -join ', '))" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty IndexingJobQueuedCount)
+ $indexingJobQueuedCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) As IndexingJobQueuedCount FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId IN ($(($indexingJobIds | ForEach-Object { "'$_'" }) -join ', '))" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam | Select-Object -ExpandProperty IndexingJobQueuedCount)
             if ($indexingJobQueuedCount -eq 0)
             {
                 Write-Log "All $EntityType indexing jobs have completed."

--- a/Azure_DevOps_Server_2022/Troubleshooting/Actions/Restart-Indexing.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Actions/Restart-Indexing.psm1
@@ -28,7 +28,10 @@ function Restart-Indexing
         [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
-        [string] $AdditionalParam
+        [string] $AdditionalParam,
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     # Reset uninstall in progress related registry keys
@@ -38,6 +41,7 @@ function Restart-Indexing
         -CollectionName $CollectionName `
         -EntityType $EntityType `
         -AdditionalParam $AdditionalParam `
+        -TrustServerCertificate:$TrustServerCertificate `
         -Confirm:$false # Don't need explicit confirmation again as executing Restart-Indexing was already confirmed by the user
 
     if (Test-BulkIndexingIsInProgress `
@@ -45,7 +49,8 @@ function Restart-Indexing
         -ConfigurationDatabaseName $ConfigurationDatabaseName `
         -CollectionDatabaseName $CollectionDatabaseName `
         -CollectionName $CollectionName `
-        -EntityType $EntityType)
+        -EntityType $EntityType `
+        -TrustServerCertificate:$TrustServerCertificate)
     {
         Write-Log "$EntityType bulk indexing of collection [$CollectionName] is already in progress. Skipping re-indexing." -Level Warn
         return
@@ -63,13 +68,14 @@ function Restart-Indexing
         -ConfigurationDatabaseName $ConfigurationDatabaseName `
         -CollectionDatabaseName $CollectionDatabaseName `
         -CollectionName $CollectionName `
-        -EntityType $EntityType
+        -EntityType $EntityType `
+            -TrustServerCertificate:$TrustServerCertificate
 
     # Reset data from SQL
-    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     $sqlParams = "CollectionId='$collectionId'", "EntityTypeString='$EntityType'", "EntityTypeInt=$(Get-EntityTypeId $EntityType)"
     $sqlFilePath = "$PSScriptRoot\..\SqlScripts\CleanUpCollectionIndexingState.sql"
-    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlParams
+    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlParams -TrustServerCertificate:$TrustServerCertificate
     Write-Log "Cleaned up all SQL tables storing indexing state."
 
     # Delete data indexed in Elasticsearch
@@ -93,7 +99,7 @@ function Restart-Indexing
     }
 
     # Get all Job Ids corresponding to all indexing units of the given entity type
-    $indexingJobIds = Invoke-Sqlcmd -Query "SELECT AssociatedJobId FROM Search.tbl_IndexingUnit WHERE EntityType = '$EntityType' AND AssociatedJobId IS NOT NULL AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty AssociatedJobId
+ $indexingJobIds = Invoke-Sqlcmd -Query "SELECT AssociatedJobId FROM Search.tbl_IndexingUnit WHERE EntityType = '$EntityType' AND AssociatedJobId IS NOT NULL AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty AssociatedJobId
     if ($indexingJobIds)
     {
         $timeoutInMinutes = 15
@@ -101,7 +107,7 @@ function Restart-Indexing
         $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         while ($stopwatch.Elapsed.TotalMinutes -lt $timeoutInMinutes) # Waiting for a maximum of $timeoutInMinutes minutes
         {
-            $indexingJobQueuedCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) As IndexingJobQueuedCount FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId IN ($(($indexingJobIds | ForEach-Object { "'$_'" }) -join ', '))" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty IndexingJobQueuedCount)
+ $indexingJobQueuedCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) As IndexingJobQueuedCount FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId IN ($(($indexingJobIds | ForEach-Object { "'$_'" }) -join ', '))" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty IndexingJobQueuedCount)
             if ($indexingJobQueuedCount -eq 0)
             {
                 Write-Log "All $EntityType indexing jobs have completed."
@@ -129,7 +135,8 @@ function Restart-Indexing
         -EntityType $EntityType `
         -WhatIf:$False `
         -Confirm:$False `
-        -Verbose:$VerbosePreference
+        -Verbose:$VerbosePreference `
+            -TrustServerCertificate:$TrustServerCertificate
 
     # Queue fault-in job if not queued already
     if (!(Test-BulkIndexingIsInProgress `
@@ -137,14 +144,16 @@ function Restart-Indexing
         -ConfigurationDatabaseName $ConfigurationDatabaseName `
         -CollectionDatabaseName $CollectionDatabaseName `
         -CollectionName $CollectionName `
-        -EntityType $EntityType))
+        -EntityType $EntityType `
+        -TrustServerCertificate:$TrustServerCertificate))
     {
         Invoke-FaultInJob `
             -SQLServerInstance $SQLServerInstance `
             -ConfigurationDatabaseName $ConfigurationDatabaseName `
             -CollectionDatabaseName $CollectionDatabaseName `
             -CollectionName $CollectionName `
-            -EntityType $EntityType
+            -EntityType $EntityType `
+                -TrustServerCertificate:$TrustServerCertificate
     }
     else
     {

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-ElasticsearchHealth.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-ElasticsearchHealth.psm1
@@ -26,7 +26,10 @@ function Test-ElasticsearchHealth
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     # Verify connection parameters are correct
@@ -48,7 +51,7 @@ function Test-ElasticsearchHealth
     }
 
     # Verify number of documents for given collection and entity type is greater than zero
-    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     
     $body = @"
     {
@@ -118,7 +121,8 @@ function Test-ElasticsearchHealth
             -ConfigurationDatabaseName $ConfigurationDatabaseName `
             -CollectionDatabaseName $CollectionDatabaseName `
             -CollectionName $CollectionName `
-            -EntityType $EntityType))
+            -EntityType $EntityType `
+            -TrustServerCertificate:$TrustServerCertificate))
         {
             Write-Log "[MANUAL ACTION MAY BE REQUIRED] No document for entity type [$EntityType] and collection [$CollectionName] is indexed in Elasticsearch. If this is not expected, consider executing Restart-Indexing action." -Level Attention
         }

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-FaultInJobInInfiniteRetries.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-FaultInJobInInfiniteRetries.psm1
@@ -31,11 +31,12 @@ function Test-FaultInJobInInfiniteRetries
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     
     # Get the latest fault-in job result message
     $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     $faultInJobId = Get-AccountFaultInJobId -EntityType $EntityType
- $faultInJobResultMessage = Invoke-Sqlcmd -Query "SELECT TOP(1) ResultMessage FROM dbo.tbl_JobHistory WHERE JobSource = '$collectionId' AND JobId = '$faultInJobId' AND Result IN (0, 2) ORDER BY StartTime DESC" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ResultMessage
+ $faultInJobResultMessage = Invoke-Sqlcmd -Query "SELECT TOP(1) ResultMessage FROM dbo.tbl_JobHistory WHERE JobSource = '$collectionId' AND JobId = '$faultInJobId' AND Result IN (0, 2) ORDER BY StartTime DESC" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam | Select-Object -ExpandProperty ResultMessage
 
     # Check if it contains the message indicating it is waiting for extension uninstallation
     if ($faultInJobResultMessage -and $faultInJobResultMessage.Contains("Requeue the Account Fault-In job since Extension Uninstall sequence is still in progress"))

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-FaultInJobInInfiniteRetries.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-FaultInJobInInfiniteRetries.psm1
@@ -26,20 +26,23 @@ function Test-FaultInJobInInfiniteRetries
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
     
     # Get the latest fault-in job result message
-    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     $faultInJobId = Get-AccountFaultInJobId -EntityType $EntityType
-    $faultInJobResultMessage = Invoke-Sqlcmd -Query "SELECT TOP(1) ResultMessage FROM dbo.tbl_JobHistory WHERE JobSource = '$collectionId' AND JobId = '$faultInJobId' AND Result IN (0, 2) ORDER BY StartTime DESC" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty ResultMessage
+ $faultInJobResultMessage = Invoke-Sqlcmd -Query "SELECT TOP(1) ResultMessage FROM dbo.tbl_JobHistory WHERE JobSource = '$collectionId' AND JobId = '$faultInJobId' AND Result IN (0, 2) ORDER BY StartTime DESC" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ResultMessage
 
     # Check if it contains the message indicating it is waiting for extension uninstallation
     if ($faultInJobResultMessage -and $faultInJobResultMessage.Contains("Requeue the Account Fault-In job since Extension Uninstall sequence is still in progress"))
     {
         # Check if the extension uninstallation in progress registry key is true
         $regKey = "\Service\ALMSearch\Settings\IsExtensionOperationInProgress\$EntityType\Uninstalled"
-        $regValue = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -RegistryPath $regKey
+        $regValue = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -RegistryPath $regKey -TrustServerCertificate:$TrustServerCertificate
         if ($regValue -eq "True")
         {
             Write-Log "$EntityType indexing is blocked due to incorrect values of some registry keys." -Level Error

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
@@ -27,6 +27,9 @@ function Test-GeneralTfvcIssues
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
     
     if ($EntityType -ne "Code")
@@ -36,7 +39,7 @@ function Test-GeneralTfvcIssues
     }
     
     # Get all job Ids corresponding to TFVC repository indexing units
-    $tfvcRepoCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) AS TfvcRepoCount FROM Search.tbl_IndexingUnit WHERE EntityType = 'Code' AND IndexingUnitType = 'TFVC_Repository' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty TfvcRepoCount)
+ $tfvcRepoCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) AS TfvcRepoCount FROM Search.tbl_IndexingUnit WHERE EntityType = 'Code' AND IndexingUnitType = 'TFVC_Repository' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty TfvcRepoCount)
     if ($tfvcRepoCount -eq 0)
     {
         Write-Log "This analyzer is only valid for TFVC repositories. No TFVC repository was found in collection [$CollectionName]."

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
@@ -31,6 +31,7 @@ function Test-GeneralTfvcIssues
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     
     if ($EntityType -ne "Code")
     {
@@ -39,7 +40,7 @@ function Test-GeneralTfvcIssues
     }
     
     # Get all job Ids corresponding to TFVC repository indexing units
- $tfvcRepoCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) AS TfvcRepoCount FROM Search.tbl_IndexingUnit WHERE EntityType = 'Code' AND IndexingUnitType = 'TFVC_Repository' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty TfvcRepoCount)
+ $tfvcRepoCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) AS TfvcRepoCount FROM Search.tbl_IndexingUnit WHERE EntityType = 'Code' AND IndexingUnitType = 'TFVC_Repository' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty TfvcRepoCount)
     if ($tfvcRepoCount -eq 0)
     {
         Write-Log "This analyzer is only valid for TFVC repositories. No TFVC repository was found in collection [$CollectionName]."

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
@@ -26,7 +26,7 @@ function Test-GeneralTfvcIssues
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
@@ -26,7 +26,7 @@ function Test-IndexingUnitPointsToDeletedIndex
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
@@ -31,11 +31,12 @@ function Test-IndexingUnitPointsToDeletedIndex
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     # Get indexing indices from all indexing units
     $sqlQueryProperties = "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchIndexingIndices.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties @trustCertParam
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
@@ -27,12 +27,15 @@ function Test-IndexingUnitPointsToDeletedIndex
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     # Get indexing indices from all indexing units
     $sqlQueryProperties = "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchIndexingIndices.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties -TrustServerCertificate:$TrustServerCertificate
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndicesHaveUnsupportedMappings.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndicesHaveUnsupportedMappings.psm1
@@ -26,7 +26,7 @@ function Test-IndicesHaveUnsupportedMappings
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndicesHaveUnsupportedMappings.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-IndicesHaveUnsupportedMappings.psm1
@@ -27,6 +27,9 @@ function Test-IndicesHaveUnsupportedMappings
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     $actionsRecommended = @()
@@ -46,7 +49,7 @@ function Test-IndicesHaveUnsupportedMappings
     }
 
     # Make sure the unsupported mappings defined above are not actually supported. This is just to make sure the script has no bugs.
-    $supportedDocumentContractType = Get-SupportedDocumentContractType -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -EntityType $EntityType
+    $supportedDocumentContractType = Get-SupportedDocumentContractType -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -EntityType $EntityType -TrustServerCertificate:$TrustServerCertificate
     $supportedMapping = Get-MappingName -DocumentContractType $supportedDocumentContractType
     if ($unsupportedMappingNames[$EntityType].Contains($supportedMapping))
     {
@@ -115,7 +118,7 @@ function Test-IndicesHaveUnsupportedMappings
         foreach ($collection in $aggregationResponse.aggregations.collections.buckets)
         {
             $affectedCollectionId = $collection.key
-            $affectedCollectionName = Get-CollectionName -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionId $affectedCollectionId
+            $affectedCollectionName = Get-CollectionName -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionId $affectedCollectionId -TrustServerCertificate:$TrustServerCertificate
             if ($affectedCollectionName -eq $CollectionName)
             {
                 Write-Log "Collection [$affectedCollectionName] has [$($collection.doc_count)] documents in the index to be deleted. It must be re-indexed." -Level Error

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-SqlHealth.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-SqlHealth.psm1
@@ -31,6 +31,7 @@ function Test-SqlHealth
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     # Verify connection parameters are correct
     Confirm-SqlIsReachable -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
@@ -93,7 +94,7 @@ function Test-SqlHealth
     }
 
     Write-Log "Verifying that collection IU is present. If not present, verifying bulk indexing is queued..."
-    if (!(Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE IndexingUnitType = 'Collection' AND EntityType = '$EntityType' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate))
+    if (!(Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE IndexingUnitType = 'Collection' AND EntityType = '$EntityType' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam))
     {
         if (Test-BulkIndexingIsInProgress `
             -SQLServerInstance $SQLServerInstance `
@@ -117,7 +118,7 @@ function Test-SqlHealth
 
     $collectionPropUrlParams = "CollectionId='$collectionID'", "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchCollectionProperties.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams @trustCertParam
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose
@@ -158,7 +159,7 @@ function Test-SqlHealth
 
     $collectionPropUrlParams = "CollectionId='$CollectionID'", "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchCollectionProperties.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams -TrustServerCertificate:$TrustServerCertificate
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams @trustCertParam
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-SqlHealth.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-SqlHealth.psm1
@@ -104,7 +104,7 @@ function Test-SqlHealth
             -EntityType $EntityType `
             -TrustServerCertificate:$TrustServerCertificate)
         {
-            Write-Log "$EntityType collection indexing unit does not exist and bulk-indexing is in progress. Skipping rest of the validations in this analyzer because they require the collection indexing unit to te present."
+            Write-Log "$EntityType collection indexing unit does not exist and bulk-indexing is in progress. Skipping rest of the validations in this analyzer because they require the collection indexing unit to be present."
             return @()
         }
     }

--- a/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-SqlHealth.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Analyzers/Test-SqlHealth.psm1
@@ -26,17 +26,20 @@ function Test-SqlHealth
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     # Verify connection parameters are correct
-    Confirm-SqlIsReachable -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName
+    Confirm-SqlIsReachable -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
     # Verify IsSearchConfigured setting in Configuration DB
     Write-Log "Verifying IsSearchConfigured setting in Configuration DB..."
 
     $configureRegKey = "\Service\ALMSearch\Settings\IsSearchConfigured"
-    $isSearchConfigured = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $configureRegKey
+    $isSearchConfigured = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $configureRegKey -TrustServerCertificate:$TrustServerCertificate
     if (!$isSearchConfigured -or $isSearchConfigured -eq "False")
     {
         Write-Log "Search is not configured." -Level Error
@@ -47,7 +50,7 @@ function Test-SqlHealth
     Write-Log "Verifying Search URL settings in Configuration DB..."
 
     $atRegKey = "\Service\ALMSearch\Settings\ATSearchPlatformConnectionString"
-    $atSearchPlatformConnectionString = [uri](Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $atRegKey)
+    $atSearchPlatformConnectionString = [uri](Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $atRegKey -TrustServerCertificate:$TrustServerCertificate)
     if (!$atSearchPlatformConnectionString)
     {
         Write-Log "AT search platform connection string registry key [$atRegKey] not found." -Level Error
@@ -60,7 +63,7 @@ function Test-SqlHealth
     }
 
     $jaRegKey = "\Service\ALMSearch\Settings\JobAgentSearchPlatformConnectionString"
-    $jaSearchPlatformConnectionString = [uri](Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $jaRegKey)
+    $jaSearchPlatformConnectionString = [uri](Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $jaRegKey -TrustServerCertificate:$TrustServerCertificate)
     if (!$jaSearchPlatformConnectionString)
     {
         Write-Log "JobAgent search platform connection string registry key [$jaRegKey] not found." -Level Error
@@ -75,7 +78,7 @@ function Test-SqlHealth
     # Verify entity specific extension is installed
     Write-Log "Verifying $EntityType search extension is installed..."
 
-    $isExtensionInstalled = Test-ExtensionInstalled -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -EntityType $EntityType
+    $isExtensionInstalled = Test-ExtensionInstalled -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -EntityType $EntityType -TrustServerCertificate:$TrustServerCertificate
     if (!$isExtensionInstalled)
     {
         return "Request-InstallSearchExtension"
@@ -83,21 +86,22 @@ function Test-SqlHealth
 
     # Verify primary indexing FFs in Configuration DB
     Write-Log "Verifying primary indexing feature flags..."
-    $indexingFeatureFlagsEnabled = Test-IndexingFeatureFlagsAreEnabled -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -EntityType $EntityType
+    $indexingFeatureFlagsEnabled = Test-IndexingFeatureFlagsAreEnabled -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -EntityType $EntityType -TrustServerCertificate:$TrustServerCertificate
     if (!$indexingFeatureFlagsEnabled)
     {
         return "Enable-IndexingFeatureFlags"
     }
 
     Write-Log "Verifying that collection IU is present. If not present, verifying bulk indexing is queued..."
-    if (!(Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE IndexingUnitType = 'Collection' AND EntityType = '$EntityType' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName))
+    if (!(Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE IndexingUnitType = 'Collection' AND EntityType = '$EntityType' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate))
     {
         if (Test-BulkIndexingIsInProgress `
             -SQLServerInstance $SQLServerInstance `
             -ConfigurationDatabaseName $ConfigurationDatabaseName `
             -CollectionDatabaseName $CollectionDatabaseName `
             -CollectionName $CollectionName `
-            -EntityType $EntityType)
+            -EntityType $EntityType `
+            -TrustServerCertificate:$TrustServerCertificate)
         {
             Write-Log "$EntityType collection indexing unit does not exist and bulk-indexing is in progress. Skipping rest of the validations in this analyzer because they require the collection indexing unit to te present."
             return @()
@@ -109,11 +113,11 @@ function Test-SqlHealth
     #                                        <QueryESConnectionString>{URL}</QueryESConnectionString>
     Write-Log "Verifying Collection IU properties' Index and Query URL match the configuration DB connection URL..."
 
-    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 
     $collectionPropUrlParams = "CollectionId='$collectionID'", "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchCollectionProperties.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams -TrustServerCertificate:$TrustServerCertificate
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose
@@ -139,7 +143,7 @@ function Test-SqlHealth
     }
     
     # Verify document contract type in registry is as expected
-    $supportedDocumentContractType = Get-SupportedDocumentContractType -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -EntityType $EntityType
+    $supportedDocumentContractType = Get-SupportedDocumentContractType -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -EntityType $EntityType -TrustServerCertificate:$TrustServerCertificate
     $expectedDocumentContractType = Get-ExpectedDocumentContractType -EntityType $EntityType
     if ($supportedDocumentContractType -ne $expectedDocumentContractType)
     {
@@ -154,7 +158,7 @@ function Test-SqlHealth
 
     $collectionPropUrlParams = "CollectionId='$CollectionID'", "EntityType='$EntityType'"
     $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchCollectionProperties.sql"
-    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams -TrustServerCertificate:$TrustServerCertificate
     if ($queryResults)
     {
         Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose

--- a/Azure_DevOps_Server_2022/Troubleshooting/Repair-Search.ps1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Repair-Search.ps1
@@ -116,6 +116,8 @@ Set-Variable LogFilePath -Option AllScope -Scope Global -Force -Value $logFilePa
 # which is prone to manual error, we will save its value in a global variable which will be accessible everywhere.
 Set-Variable RepairSearchVerbosePreference -Option ReadOnly -Scope Global -Force -Value $VerbosePreference -Confirm:$false -WhatIf:$false
 
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
+
 try
 {
     Write-Log "=== Start Repair-Search ===" -Verbose:$VerbosePreference
@@ -148,7 +150,7 @@ try
             -ElasticsearchServiceUrl $ElasticsearchServiceUrl `
             -ElasticsearchServiceCredential $ElasticsearchServiceCredential `
             -EntityType $EntityType `
-            -TrustServerCertificate:$TrustServerCertificate `
+            @trustCertParam `
             -Verbose:$VerbosePreference `
             -WhatIf:$WhatIfPreference `
             -Confirm:$confirmationRequired `
@@ -222,7 +224,7 @@ try
                 -ElasticsearchServiceCredential $ElasticsearchServiceCredential `
                 -EntityType $EntityType `
                 -AdditionalParam $additionalParam `
-                -TrustServerCertificate:$TrustServerCertificate `
+                @trustCertParam `
                 -Verbose:$VerbosePreference `
                 -WhatIf:$WhatIfPreference `
                 -Confirm:$confirmationRequired `

--- a/Azure_DevOps_Server_2022/Troubleshooting/Repair-Search.ps1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Repair-Search.ps1
@@ -38,6 +38,9 @@
     .PARAMETER EntityType
     Entity type of the impacted collection.
 
+    .PARAMETER TrustServerCertificate
+    If specified, the server certificate is trusted when connecting to SQL Server. Use this when SQL Server uses a self-signed certificate.
+
     .INPUTS
     None. You cannot pipe objects to Repair-Search.
 
@@ -93,7 +96,10 @@ Param
 
     [Parameter(Mandatory=$True)]
     [ValidateSet("Code", "WorkItem", "Wiki")]
-    [string] $EntityType
+    [string] $EntityType,
+
+    [Parameter(Mandatory=$False)]
+    [switch] $TrustServerCertificate
 )
 
 $ErrorActionPreference = "Stop" # We do not want to continue executing the script if we encounter a failure
@@ -142,6 +148,7 @@ try
             -ElasticsearchServiceUrl $ElasticsearchServiceUrl `
             -ElasticsearchServiceCredential $ElasticsearchServiceCredential `
             -EntityType $EntityType `
+            -TrustServerCertificate:$TrustServerCertificate `
             -Verbose:$VerbosePreference `
             -WhatIf:$WhatIfPreference `
             -Confirm:$confirmationRequired `
@@ -215,6 +222,7 @@ try
                 -ElasticsearchServiceCredential $ElasticsearchServiceCredential `
                 -EntityType $EntityType `
                 -AdditionalParam $additionalParam `
+                -TrustServerCertificate:$TrustServerCertificate `
                 -Verbose:$VerbosePreference `
                 -WhatIf:$WhatIfPreference `
                 -Confirm:$confirmationRequired `

--- a/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
@@ -77,7 +77,7 @@ function Get-CollectionId
         [string] $ConfigurationDatabaseName,
 
         [Parameter(Mandatory=$True)]
-        [string] $CollectionName
+        [string] $CollectionName,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -114,7 +114,7 @@ function Confirm-CollectionIsInStartedState
         [string] $ConfigurationDatabaseName,
 
         [Parameter(Mandatory=$True)]
-        [string] $CollectionName
+        [string] $CollectionName,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -149,7 +149,7 @@ function Get-DeploymentHostId
         [string] $SQLServerInstance,
 
         [Parameter(Mandatory=$True)]
-        [string] $ConfigurationDatabaseName
+        [string] $ConfigurationDatabaseName,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -378,7 +378,7 @@ function Test-ExtensionInstalled
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType,
-
+        
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )

--- a/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
@@ -44,10 +44,11 @@ function Get-CollectionName
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     try
     {
-        $results = Invoke-Sqlcmd -Query "Select Name from dbo.tbl_ServiceHost WHERE HostId = '$CollectionId' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop -TrustServerCertificate:$TrustServerCertificate
+        $results = Invoke-Sqlcmd -Query "Select Name from dbo.tbl_ServiceHost WHERE HostId = '$CollectionId' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop @trustCertParam
         if (!$results)
         {
             throw "Either the collection with Id [$CollectionId] does not exist or it is in a detached state."
@@ -81,10 +82,11 @@ function Get-CollectionId
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     try
     {
-        $results = Invoke-Sqlcmd -Query "Select HostId from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop -TrustServerCertificate:$TrustServerCertificate
+        $results = Invoke-Sqlcmd -Query "Select HostId from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop @trustCertParam
         if (!$results)
         {
             throw "Either collection [$CollectionName] does not exist or it is in a detached state."
@@ -117,8 +119,9 @@ function Confirm-CollectionIsInStartedState
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
-    $results = Invoke-Sqlcmd -Query "Select Status from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+    $results = Invoke-Sqlcmd -Query "Select Status from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam
     if (!$results)
     {
         throw [ArgumentException]"Either collection [$CollectionName] does not exist or it is in a detached state."
@@ -151,8 +154,9 @@ function Get-DeploymentHostId
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
- $deploymentHostId = Invoke-Sqlcmd -Query "Select HostID from dbo.tbl_ServiceHost WHERE Name = 'TEAM FOUNDATION' AND HostType = 3" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty HostId
+ $deploymentHostId = Invoke-Sqlcmd -Query "Select HostID from dbo.tbl_ServiceHost WHERE Name = 'TEAM FOUNDATION' AND HostType = 3" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam | Select-Object -ExpandProperty HostId
     if (!$deploymentHostId)
     {
         throw "Deployment host Id not found."
@@ -186,13 +190,14 @@ function Confirm-SqlIsReachable
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     $partitionId = $null
 
     try
     {
- $partitionId = Invoke-Sqlcmd -Query "SELECT PartitionId FROM dbo.tbl_DatabasePartitionMap WHERE ServiceHostId = '$collectionId'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -ErrorAction Stop -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty PartitionId
+ $partitionId = Invoke-Sqlcmd -Query "SELECT PartitionId FROM dbo.tbl_DatabasePartitionMap WHERE ServiceHostId = '$collectionId'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -ErrorAction Stop @trustCertParam | Select-Object -ExpandProperty PartitionId
     }
     catch
     {
@@ -377,12 +382,13 @@ function Test-ExtensionInstalled
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     switch ($EntityType)
     {
         "Code"
         {
- $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM Extension.tbl_InstalledExtension WHERE PublisherName = 'ms' and ExtensionName = 'vss-code-search'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ExtensionName
+ $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM Extension.tbl_InstalledExtension WHERE PublisherName = 'ms' and ExtensionName = 'vss-code-search'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty ExtensionName
             if (!$extensionName)
             {
                 Write-Log "$_ search extension is not installed" -Level Warn
@@ -402,7 +408,7 @@ function Test-ExtensionInstalled
 
         "WorkItem"
         {
- $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-workitem-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ExtensionName
+ $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-workitem-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty ExtensionName
             if (!$extensionName)
             {
                 Write-Log "$_ search extension is not installed" -Level Warn
@@ -422,7 +428,7 @@ function Test-ExtensionInstalled
 
         "Wiki"
         {
- $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-wiki-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ExtensionName
+ $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-wiki-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty ExtensionName
             if (!$extensionName)
             {
                 Write-Log "$_ search extension is not installed" -Level Warn
@@ -642,6 +648,7 @@ function Get-ServiceRegistryValue
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     $parentPath = "#$(Split-Path $RegistryPath -Parent -ErrorAction Stop)\"
     Write-Log "ParentPath = [$parentPath]." -Level Verbose
@@ -650,11 +657,11 @@ function Get-ServiceRegistryValue
 
     if ($CollectionDatabaseName)
     {
- return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
+ return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty RegValue
     }
     else
     {
- return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
+ return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam | Select-Object -ExpandProperty RegValue
     }
 }
 
@@ -684,6 +691,7 @@ function Set-ServiceRegistryValue
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     if (!$Value)
     {
@@ -703,13 +711,13 @@ function Set-ServiceRegistryValue
     {
         $command = "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $Value"
         Write-Log "Command = $command" -Level Verbose
-        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam
     }
     else
     {
         $command = "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $Value"
         Write-Log "Command = $command" -Level Verbose
-        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam
     }
 }
 
@@ -737,15 +745,16 @@ function Get-FeatureFlag
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     $parentPath = "#\FeatureAvailability\Entries\$FeatureName\"
     $childItem = "AvailabilityState\"
 
     if ($CollectionDatabaseName)
     {
- $collectionHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
+ $collectionHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty RegValue
         Write-Log "State of feature flag [$FeatureName] in collection DB is [$collectionHostValue]." -Level Verbose
- $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
+ $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam | Select-Object -ExpandProperty RegValue
         Write-Log "State of feature flag [$FeatureName] in configuration DB is [$deploymentHostValue]." -Level Verbose
 
         $effectiveValue =  (($deploymentHostValue -eq 1 -and $collectionHostValue -eq $null) -or ($deploymentHostValue -eq $null -and $collectionHostValue -eq 1) -or ($deploymentHostValue -eq 1 -and $collectionHostValue -eq 1))
@@ -753,7 +762,7 @@ function Get-FeatureFlag
     }
     else
     {
- $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
+ $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam | Select-Object -ExpandProperty RegValue
         return $deploymentHostValue -eq 1
     }
 }
@@ -785,6 +794,7 @@ function Set-FeatureFlag
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     $parentPath = "#\FeatureAvailability\Entries\$FeatureName\"
     $childItem = "AvailabilityState\"
@@ -801,11 +811,11 @@ function Set-FeatureFlag
 
     if ($CollectionDatabaseName)
     {
-        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam
     }
     else
     {
-        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
+        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam
     }
 }
 
@@ -829,6 +839,7 @@ function Queue-ServiceJob
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
     if (!$CollectionName) # Deployment host job
     {
@@ -841,7 +852,7 @@ function Queue-ServiceJob
 
     $sqlParams = "HostId='$hostId'", "JobId='$JobId'"
     $sqlFilePath = "$PSScriptRoot\..\SqlScripts\QueueJob.sql"
-    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -Variable $sqlParams -TrustServerCertificate:$TrustServerCertificate
+    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -Variable $sqlParams @trustCertParam
 }
 
 function Test-BulkIndexingIsInProgress
@@ -869,39 +880,40 @@ function Test-BulkIndexingIsInProgress
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
     )
+    $trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
     
     $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     
     # If fault-in job in queue or in progress, bulk indexing is in progress.
- $faultInJobQueueTime = Invoke-Sqlcmd -Query "SELECT QueueTime FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId = '$(Get-AccountFaultInJobId -EntityType $EntityType)' AND JobState >= 0" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty QueueTime
+ $faultInJobQueueTime = Invoke-Sqlcmd -Query "SELECT QueueTime FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId = '$(Get-AccountFaultInJobId -EntityType $EntityType)' AND JobState >= 0" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName @trustCertParam | Select-Object -ExpandProperty QueueTime
     if ($faultInJobQueueTime)
     {
         return $true
     }
 
     # If collection indexing unit is not present, bulk indexing is not in progress.
- $collectionIndexingUnitId = Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE TfsEntityId = '$collectionId' AND EntityType = '$EntityType' AND IndexingUnitType = 'Collection' AND IsDeleted = 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty IndexingUnitId
+ $collectionIndexingUnitId = Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE TfsEntityId = '$collectionId' AND EntityType = '$EntityType' AND IndexingUnitType = 'Collection' AND IsDeleted = 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty IndexingUnitId
     if (!$collectionIndexingUnitId)
     {
         return $false
     }
     
     # If crawl metadata operation is in queue or in progress, bulk indexing is in progress.
- $crawlMetadataOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CrawlMetadata' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty Id
+ $crawlMetadataOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CrawlMetadata' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty Id
     if ($crawlMetadataOperationId)
     {
         return $true
     }
     
     # If collection begin bulk indexing operation is in queue or in progress, bulk indexing is in progress.
- $collectionBeginBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'BeginBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty Id
+ $collectionBeginBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'BeginBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty Id
     if ($collectionBeginBulkIndexOperationId)
     {
         return $true
     }
     
     # If collection complete bulk indexing operation is in queue or in progress, bulk indexing is in progress.
- $collectionCompleteBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CompleteBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty Id
+ $collectionCompleteBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CompleteBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName @trustCertParam | Select-Object -ExpandProperty Id
     if ($collectionCompleteBulkIndexOperationId)
     {
         return $true

--- a/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
@@ -39,7 +39,7 @@ function Get-CollectionName
         [string] $ConfigurationDatabaseName,
 
         [Parameter(Mandatory=$True)]
-        [guid] $CollectionId
+        [guid] $CollectionId,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate

--- a/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
@@ -185,7 +185,7 @@ function Confirm-SqlIsReachable
         [string] $CollectionDatabaseName,
 
         [Parameter(Mandatory=$True)]
-        [string] $CollectionName
+        [string] $CollectionName,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -377,7 +377,7 @@ function Test-ExtensionInstalled
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -472,7 +472,7 @@ function Test-IndexingFeatureFlagsAreEnabled
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -555,7 +555,7 @@ function Disable-IndexingFeatureFlags
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -614,7 +614,7 @@ function Invoke-FaultInJob
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -643,7 +643,7 @@ function Get-ServiceRegistryValue
         [string] $CollectionName,
 
         [Parameter(Mandatory=$True)]
-        [string] $RegistryPath
+        [string] $RegistryPath,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -686,7 +686,7 @@ function Set-ServiceRegistryValue
         [string] $RegistryPath,
 
         [Parameter(Mandatory=$False)]
-        [string] $Value
+        [string] $Value,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -740,7 +740,7 @@ function Get-FeatureFlag
         [string] $CollectionName,
 
         [Parameter(Mandatory=$True)]
-        [string] $FeatureName
+        [string] $FeatureName,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -789,7 +789,7 @@ function Set-FeatureFlag
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("On", "Off", "Undefined")]
-        [string] $State
+        [string] $State,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -834,7 +834,7 @@ function Queue-ServiceJob
         [string] $CollectionName,
 
         [Parameter(Mandatory=$True)]
-        [guid] $JobId
+        [guid] $JobId,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -875,7 +875,7 @@ function Test-BulkIndexingIsInProgress
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate
@@ -984,7 +984,7 @@ function Get-SupportedDocumentContractType
 
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
-        [string] $EntityType
+        [string] $EntityType,
 
         [Parameter(Mandatory=$False)]
         [switch] $TrustServerCertificate

--- a/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
+++ b/Azure_DevOps_Server_2022/Troubleshooting/Utils/Common.psm1
@@ -40,11 +40,14 @@ function Get-CollectionName
 
         [Parameter(Mandatory=$True)]
         [guid] $CollectionId
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     try
     {
-        $results = Invoke-Sqlcmd -Query "Select Name from dbo.tbl_ServiceHost WHERE HostId = '$CollectionId' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop
+        $results = Invoke-Sqlcmd -Query "Select Name from dbo.tbl_ServiceHost WHERE HostId = '$CollectionId' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop -TrustServerCertificate:$TrustServerCertificate
         if (!$results)
         {
             throw "Either the collection with Id [$CollectionId] does not exist or it is in a detached state."
@@ -74,11 +77,14 @@ function Get-CollectionId
 
         [Parameter(Mandatory=$True)]
         [string] $CollectionName
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     try
     {
-        $results = Invoke-Sqlcmd -Query "Select HostId from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop
+        $results = Invoke-Sqlcmd -Query "Select HostId from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -ErrorAction Stop -TrustServerCertificate:$TrustServerCertificate
         if (!$results)
         {
             throw "Either collection [$CollectionName] does not exist or it is in a detached state."
@@ -107,9 +113,12 @@ function Confirm-CollectionIsInStartedState
 
         [Parameter(Mandatory=$True)]
         [string] $CollectionName
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
-    $results = Invoke-Sqlcmd -Query "Select Status from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName
+    $results = Invoke-Sqlcmd -Query "Select Status from dbo.tbl_ServiceHost WHERE Name = '$CollectionName' AND HostType = 4" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
     if (!$results)
     {
         throw [ArgumentException]"Either collection [$CollectionName] does not exist or it is in a detached state."
@@ -138,9 +147,12 @@ function Get-DeploymentHostId
 
         [Parameter(Mandatory=$True)]
         [string] $ConfigurationDatabaseName
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
-    $deploymentHostId = Invoke-Sqlcmd -Query "Select HostID from dbo.tbl_ServiceHost WHERE Name = 'TEAM FOUNDATION' AND HostType = 3" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty HostId
+ $deploymentHostId = Invoke-Sqlcmd -Query "Select HostID from dbo.tbl_ServiceHost WHERE Name = 'TEAM FOUNDATION' AND HostType = 3" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty HostId
     if (!$deploymentHostId)
     {
         throw "Deployment host Id not found."
@@ -170,14 +182,17 @@ function Confirm-SqlIsReachable
 
         [Parameter(Mandatory=$True)]
         [string] $CollectionName
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
-    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     $partitionId = $null
 
     try
     {
-        $partitionId = Invoke-Sqlcmd -Query "SELECT PartitionId FROM dbo.tbl_DatabasePartitionMap WHERE ServiceHostId = '$collectionId'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -ErrorAction Stop | Select-Object -ExpandProperty PartitionId
+ $partitionId = Invoke-Sqlcmd -Query "SELECT PartitionId FROM dbo.tbl_DatabasePartitionMap WHERE ServiceHostId = '$collectionId'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -ErrorAction Stop -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty PartitionId
     }
     catch
     {
@@ -194,7 +209,7 @@ function Confirm-SqlIsReachable
         throw "Expected partition Id of the collection [$CollectionName] in database [$CollectionDatabaseName] to be 1, but found $partitionId. This could indicate a non-supported deployment."
     }
 
-    Confirm-CollectionIsInStartedState -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    Confirm-CollectionIsInStartedState -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
 }
 
 function Invoke-ElasticsearchCommand
@@ -358,20 +373,23 @@ function Test-ExtensionInstalled
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     switch ($EntityType)
     {
         "Code"
         {
-            $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM Extension.tbl_InstalledExtension WHERE PublisherName = 'ms' and ExtensionName = 'vss-code-search'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty ExtensionName
+ $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM Extension.tbl_InstalledExtension WHERE PublisherName = 'ms' and ExtensionName = 'vss-code-search'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ExtensionName
             if (!$extensionName)
             {
                 Write-Log "$_ search extension is not installed" -Level Warn
                 return $false
             }
 
-            $isExtensionInstalRecorded = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -RegistryPath "\Service\ALMSearch\Settings\IsCollectionIndexed"
+            $isExtensionInstalRecorded = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -RegistryPath "\Service\ALMSearch\Settings\IsCollectionIndexed" -TrustServerCertificate:$TrustServerCertificate
             
             if (!$isExtensionInstalRecorded)
             {
@@ -384,14 +402,14 @@ function Test-ExtensionInstalled
 
         "WorkItem"
         {
-            $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-workitem-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty ExtensionName
+ $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-workitem-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ExtensionName
             if (!$extensionName)
             {
                 Write-Log "$_ search extension is not installed" -Level Warn
                 return $false
             }
             
-            $isExtensionInstalRecorded = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -RegistryPath "\Service\ALMSearch\Settings\IsCollectionIndexedForWorkItem"
+            $isExtensionInstalRecorded = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -RegistryPath "\Service\ALMSearch\Settings\IsCollectionIndexedForWorkItem" -TrustServerCertificate:$TrustServerCertificate
             
             if (!$isExtensionInstalRecorded)
             {
@@ -404,14 +422,14 @@ function Test-ExtensionInstalled
 
         "Wiki"
         {
-            $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-wiki-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty ExtensionName
+ $extensionName = Invoke-Sqlcmd -Query "SELECT ExtensionName FROM [Extension].[tbl_InstalledExtension] where PublisherName = 'ms' and ExtensionName = 'vss-wiki-searchonprem'" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty ExtensionName
             if (!$extensionName)
             {
                 Write-Log "$_ search extension is not installed" -Level Warn
                 return $false
             }
             
-            $isExtensionInstalRecorded = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -RegistryPath "\Service\ALMSearch\Settings\IsCollectionIndexedForWiki"
+            $isExtensionInstalRecorded = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -RegistryPath "\Service\ALMSearch\Settings\IsCollectionIndexedForWiki" -TrustServerCertificate:$TrustServerCertificate
             
             if (!$isExtensionInstalRecorded)
             {
@@ -449,19 +467,22 @@ function Test-IndexingFeatureFlagsAreEnabled
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     switch ($EntityType)
     {
         "Code"
         {
-            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.Indexing"))
+            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.Indexing" -TrustServerCertificate:$TrustServerCertificate))
             {
                 Write-Log "Search.Server.Code.Indexing feature flag is not enabled." -Level Error
                 return $false
             }
             
-            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.CrudOperations"))
+            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.CrudOperations" -TrustServerCertificate:$TrustServerCertificate))
             {
                 Write-Log "Search.Server.Code.CrudOperations feature flag is not enabled." -Level Error
                 return $false
@@ -472,12 +493,12 @@ function Test-IndexingFeatureFlagsAreEnabled
 
         "WorkItem"
         {
-            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.Indexing"))
+            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.Indexing" -TrustServerCertificate:$TrustServerCertificate))
             {
                 Write-Log "Search.Server.WorkItem.Indexing feature flag is not enabled." -Level Error
                 return $false
             }
-            elseif (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.CrudOperations"))
+            elseif (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.CrudOperations" -TrustServerCertificate:$TrustServerCertificate))
             {
                 Write-Log "Search.Server.WorkItem.CrudOperations feature flag is not enabled." -Level Error
                 return $false
@@ -488,12 +509,12 @@ function Test-IndexingFeatureFlagsAreEnabled
 
         "Wiki"
         {
-            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.Indexing"))
+            if (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.Indexing" -TrustServerCertificate:$TrustServerCertificate))
             {
                 Write-Log "Search.Server.Wiki.Indexing feature flag is not enabled." -Level Error
                 return $false
             }
-            elseif (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.ContinuousIndexing"))
+            elseif (!(Get-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -TrustServerCertificate:$TrustServerCertificate))
             {
                 Write-Log "Search.Server.Wiki.ContinuousIndexing feature flag is not enabled." -Level Error
                 return $false
@@ -529,6 +550,9 @@ function Disable-IndexingFeatureFlags
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     Write-Log "Disabling [$EntityType] indexing feature flags for collection [$CollectionName]..."
@@ -536,22 +560,22 @@ function Disable-IndexingFeatureFlags
     {
         "Code"
         {
-            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.Indexing" -State Off
-            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.CrudOperations" -State Off
+            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.Indexing" -State Off -TrustServerCertificate:$TrustServerCertificate
+            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.CrudOperations" -State Off -TrustServerCertificate:$TrustServerCertificate
             break
         }
 
         "WorkItem"
         {
-            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.Indexing" -State Off
-            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.CrudOperations" -State Off
+            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.Indexing" -State Off -TrustServerCertificate:$TrustServerCertificate
+            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.CrudOperations" -State Off -TrustServerCertificate:$TrustServerCertificate
             break
         }
 
         "Wiki"
         {
-            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.Indexing" -State Off
-            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State Off
+            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.Indexing" -State Off -TrustServerCertificate:$TrustServerCertificate
+            Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State Off -TrustServerCertificate:$TrustServerCertificate
             break
         }
             
@@ -585,9 +609,12 @@ function Invoke-FaultInJob
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
-    Queue-ServiceJob -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -JobId (Get-AccountFaultInJobId -EntityType $EntityType)
+    Queue-ServiceJob -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -JobId (Get-AccountFaultInJobId -EntityType $EntityType) -TrustServerCertificate:$TrustServerCertificate
     Write-Log "Queued [$EntityType] bulk indexing of collection [$CollectionName]."
 }
 
@@ -611,6 +638,9 @@ function Get-ServiceRegistryValue
 
         [Parameter(Mandatory=$True)]
         [string] $RegistryPath
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     $parentPath = "#$(Split-Path $RegistryPath -Parent -ErrorAction Stop)\"
@@ -620,11 +650,11 @@ function Get-ServiceRegistryValue
 
     if ($CollectionDatabaseName)
     {
-        return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty RegValue
+ return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
     }
     else
     {
-        return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty RegValue
+ return Invoke-Sqlcmd -Query "SELECT RegValue FROM dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
     }
 }
 
@@ -650,6 +680,9 @@ function Set-ServiceRegistryValue
 
         [Parameter(Mandatory=$False)]
         [string] $Value
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     if (!$Value)
@@ -670,13 +703,13 @@ function Set-ServiceRegistryValue
     {
         $command = "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $Value"
         Write-Log "Command = $command" -Level Verbose
-        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName
+        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
     }
     else
     {
         $command = "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $Value"
         Write-Log "Command = $command" -Level Verbose
-        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName
+        Invoke-Sqlcmd -Query $command -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
     }
 }
 
@@ -700,6 +733,9 @@ function Get-FeatureFlag
 
         [Parameter(Mandatory=$True)]
         [string] $FeatureName
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     $parentPath = "#\FeatureAvailability\Entries\$FeatureName\"
@@ -707,9 +743,9 @@ function Get-FeatureFlag
 
     if ($CollectionDatabaseName)
     {
-        $collectionHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty RegValue
+ $collectionHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
         Write-Log "State of feature flag [$FeatureName] in collection DB is [$collectionHostValue]." -Level Verbose
-        $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty RegValue
+ $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
         Write-Log "State of feature flag [$FeatureName] in configuration DB is [$deploymentHostValue]." -Level Verbose
 
         $effectiveValue =  (($deploymentHostValue -eq 1 -and $collectionHostValue -eq $null) -or ($deploymentHostValue -eq $null -and $collectionHostValue -eq 1) -or ($deploymentHostValue -eq 1 -and $collectionHostValue -eq 1))
@@ -717,7 +753,7 @@ function Get-FeatureFlag
     }
     else
     {
-        $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty RegValue
+ $deploymentHostValue = Invoke-Sqlcmd -Query "SELECT RegValue from dbo.tbl_RegistryItems WHERE ParentPath = '$parentPath' AND ChildItem = '$childItem' AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty RegValue
         return $deploymentHostValue -eq 1
     }
 }
@@ -745,6 +781,9 @@ function Set-FeatureFlag
         [Parameter(Mandatory=$True)]
         [ValidateSet("On", "Off", "Undefined")]
         [string] $State
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     $parentPath = "#\FeatureAvailability\Entries\$FeatureName\"
@@ -762,11 +801,11 @@ function Set-FeatureFlag
 
     if ($CollectionDatabaseName)
     {
-        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName
+        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate
     }
     else
     {
-        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName
+        Invoke-Sqlcmd -Query "EXEC prc_SetRegistryValue @partitionId = 1, @key = '$parentPath$childItem', @value = $regValue" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
     }
 }
 
@@ -786,20 +825,23 @@ function Queue-ServiceJob
 
         [Parameter(Mandatory=$True)]
         [guid] $JobId
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     if (!$CollectionName) # Deployment host job
     {
-        $hostId = Get-DeploymentHostId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName
+        $hostId = Get-DeploymentHostId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate
     }
     else # Collection host job
     {
-        $hostId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+        $hostId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     }
 
     $sqlParams = "HostId='$hostId'", "JobId='$JobId'"
     $sqlFilePath = "$PSScriptRoot\..\SqlScripts\QueueJob.sql"
-    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -Variable $sqlParams
+    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -Variable $sqlParams -TrustServerCertificate:$TrustServerCertificate
 }
 
 function Test-BulkIndexingIsInProgress
@@ -823,40 +865,43 @@ function Test-BulkIndexingIsInProgress
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
     
-    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName -TrustServerCertificate:$TrustServerCertificate
     
     # If fault-in job in queue or in progress, bulk indexing is in progress.
-    $faultInJobQueueTime = Invoke-Sqlcmd -Query "SELECT QueueTime FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId = '$(Get-AccountFaultInJobId -EntityType $EntityType)' AND JobState >= 0" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty QueueTime
+ $faultInJobQueueTime = Invoke-Sqlcmd -Query "SELECT QueueTime FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId = '$(Get-AccountFaultInJobId -EntityType $EntityType)' AND JobState >= 0" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty QueueTime
     if ($faultInJobQueueTime)
     {
         return $true
     }
 
     # If collection indexing unit is not present, bulk indexing is not in progress.
-    $collectionIndexingUnitId = Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE TfsEntityId = '$collectionId' AND EntityType = '$EntityType' AND IndexingUnitType = 'Collection' AND IsDeleted = 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty IndexingUnitId
+ $collectionIndexingUnitId = Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE TfsEntityId = '$collectionId' AND EntityType = '$EntityType' AND IndexingUnitType = 'Collection' AND IsDeleted = 0" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty IndexingUnitId
     if (!$collectionIndexingUnitId)
     {
         return $false
     }
     
     # If crawl metadata operation is in queue or in progress, bulk indexing is in progress.
-    $crawlMetadataOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CrawlMetadata' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty Id
+ $crawlMetadataOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CrawlMetadata' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty Id
     if ($crawlMetadataOperationId)
     {
         return $true
     }
     
     # If collection begin bulk indexing operation is in queue or in progress, bulk indexing is in progress.
-    $collectionBeginBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'BeginBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty Id
+ $collectionBeginBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'BeginBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty Id
     if ($collectionBeginBulkIndexOperationId)
     {
         return $true
     }
     
     # If collection complete bulk indexing operation is in queue or in progress, bulk indexing is in progress.
-    $collectionCompleteBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CompleteBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty Id
+ $collectionCompleteBulkIndexOperationId = Invoke-Sqlcmd -Query "SELECT Id FROM Search.tbl_IndexingUnitChangeEvent WHERE IndexingUnitId = $collectionIndexingUnitId AND ChangeType = 'CompleteBulkIndex' AND State IN ('Pending', 'Queued', 'InProgress')" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -TrustServerCertificate:$TrustServerCertificate | Select-Object -ExpandProperty Id
     if ($collectionCompleteBulkIndexOperationId)
     {
         return $true
@@ -928,6 +973,9 @@ function Get-SupportedDocumentContractType
         [Parameter(Mandatory=$True)]
         [ValidateSet("Code", "WorkItem", "Wiki")]
         [string] $EntityType
+
+        [Parameter(Mandatory=$False)]
+        [switch] $TrustServerCertificate
     )
 
     $registryPath = $null
@@ -957,7 +1005,7 @@ function Get-SupportedDocumentContractType
         }
     }
 
-    $supportedContractType = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $registryPath
+    $supportedContractType = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $registryPath -TrustServerCertificate:$TrustServerCertificate
     Write-Log "Supported document contract type for entity type [$EntityType] = [$supportedContractType]." -Level Verbose
     return $supportedContractType
 }

--- a/Azure_DevOps_Server_2022/ViewDelete-IncompatibleIndices.ps1
+++ b/Azure_DevOps_Server_2022/ViewDelete-IncompatibleIndices.ps1
@@ -21,11 +21,12 @@ param (
 
     [Parameter(Mandatory = $true, Position = 5, HelpMessage = "Action to perform.")]
     [ValidateSet("Delete", "View")]
-    [string]$Action
+    [string]$Action,
 
     [Parameter(Mandatory=$False)]
     [switch]$TrustServerCertificate
 )
+$trustCertParam = if ($TrustServerCertificate) { @{TrustServerCertificate = $true} } else { @{} }
 
 $indicesFilePath = Join-Path $PSScriptRoot "indices.txt"
 $settingsFilePath = Join-Path $PSScriptRoot "settings.txt"
@@ -73,7 +74,7 @@ foreach ($index in $indices) {
         
         $Params = "IndexName='$indexName'"
         $sqlFullPath = Join-Path $PSScriptRoot 'SqlScripts\GetActiveIncompatibleIndex.sql'
-        $result = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $params -TrustServerCertificate:$TrustServerCertificate
+        $result = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $params @trustCertParam
 
         Write-Host "Result: $($result.Count)" -ForegroundColor Red
 

--- a/Azure_DevOps_Server_2022/ViewDelete-IncompatibleIndices.ps1
+++ b/Azure_DevOps_Server_2022/ViewDelete-IncompatibleIndices.ps1
@@ -1,4 +1,4 @@
-﻿<# 
+<# 
 Execute this script to identify any active indexes that are incompatible. If any indexes are in use, 
 reindex the collection using the TriggerCollection script, and then rerun this script with the Delete action selected.
 #>
@@ -22,6 +22,9 @@ param (
     [Parameter(Mandatory = $true, Position = 5, HelpMessage = "Action to perform.")]
     [ValidateSet("Delete", "View")]
     [string]$Action
+
+    [Parameter(Mandatory=$False)]
+    [switch]$TrustServerCertificate
 )
 
 $indicesFilePath = Join-Path $PSScriptRoot "indices.txt"
@@ -70,7 +73,7 @@ foreach ($index in $indices) {
         
         $Params = "IndexName='$indexName'"
         $sqlFullPath = Join-Path $PSScriptRoot 'SqlScripts\GetActiveIncompatibleIndex.sql'
-        $result = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $params
+        $result = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $params -TrustServerCertificate:$TrustServerCertificate
 
         Write-Host "Result: $($result.Count)" -ForegroundColor Red
 


### PR DESCRIPTION
Starting with SQL Server 2022 (and enforced in newer versions of the SqlServer PowerShell module), **Invoke-Sqlcmd** requires an explicit opt-in to trust self-signed or non-CA-issued TLS certificates on the SQL Server connection. Without it, connections to SQL Server instances using such certificates fail with a certificate validation error. The -TrustServerCertificate switch suppresses that validation — but it must only be passed when the administrator explicitly requests it, because silently trusting any certificate would bypass a security control. PowerShell conditional splatting (@trustCertParam) ensures the flag is appended to Invoke-Sqlcmd only when the operator passes -TrustServerCertificate at the script level, leaving the default behaviour (certificate verification) unchanged for all other users.

**Changes Made**
Added [switch]$TrustServerCertificate to root Common.psm1 (ValidateCollectionName, IsExtensionInstalled)
Added [switch]$TrustServerCertificate to SearchDiagonistics/Common.psm1
Added [switch]$TrustServerCertificate to all 19 root .ps1 scripts
Added [switch]$TrustServerCertificate to SearchDiagonistics scripts
Added [switch]$TrustServerCertificate to 16 functions in Troubleshooting/Utils/Common.psm1
Added [switch]$TrustServerCertificate to all Troubleshooting Analyzer modules (6 files)
Added [switch]$TrustServerCertificate to Troubleshooting Action modules that use SQL (4 files)
Added [switch]$TrustServerCertificate to Troubleshooting/Repair-Search.ps1 with inline help documentation
All 105 Invoke-Sqlcmd calls use conditional splatting — -TrustServerCertificate is only passed when the user explicitly enables the switch (never passed as $false)
All internal function call chains propagate $TrustServerCertificate