### PR TITLE
Add ADO Server 2025 scripts (part 1 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/CleanUpShardDetails.ps1
+++ b/ADO_Server_Diagnostics_2025/CleanUpShardDetails.ps1
@@ -1,0 +1,21 @@
+﻿<#
+This scripts cleans the shard details table from the configuration database
+#>
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True, Position=0, HelpMessage="The Server Instance against which the script is to run.")]
+    [string]$SQLServerInstance,
+
+    [Parameter(Mandatory=$True, Position=1, HelpMessage="Configuration DB")]
+    [string]$ConfigurationDatabaseName
+)
+
+function CleanupShardDetails
+{
+    $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CleanUpShardDetailsTable.sql'
+    Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose
+    Write-Host "Cleaned up the shard details..." -ForegroundColor Yellow
+}
+
+CleanupShardDetails

--- a/ADO_Server_Diagnostics_2025/EnableSearchForChineseCharacters.ps1
+++ b/ADO_Server_Diagnostics_2025/EnableSearchForChineseCharacters.ps1
@@ -1,0 +1,148 @@
+<#
+Script to add search support for Chinese characters.
+For creating new index mappings customer has to clean search and reconfigure it.
+We are enabling feature flags and then cleaning up the existing search. 
+If customer hasn't installed search yet, then we would just enable the FF and exit from there. Customer can configure search
+after that.
+#>
+
+[CmdletBinding()]
+Param
+(
+    [Parameter(Mandatory=$True, Position=0, HelpMessage="The Server Instance against which the script is to run.")]
+    [string]$SQLServerInstance,
+   
+    [Parameter(Mandatory=$True, Position=1, HelpMessage="Collection Database name.")]
+    [string]$CollectionDatabaseName,
+    
+    [Parameter(Mandatory=$True, Position=2, HelpMessage="Configuration Database name.")]
+    [string]$ConfigurationDatabaseName,
+   
+    [Parameter(Mandatory=$True, Position=3, HelpMessage="Collection name.")]
+    [string]$CollectionName
+)
+
+Import-Module "$PSScriptRoot\Common.psm1" -Force
+
+function IsCurrentUserAdmin
+{
+    [CmdletBinding()]
+    param()
+
+    If (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
+    {
+	    return $true
+    }
+    return $false
+}
+
+function IsResetConfirm
+{
+    [OutputType([boolean])]
+    Param
+    (
+    [string]$message
+    )
+    Write-Host $message  -NoNewline -ForegroundColor Magenta
+    $confirm = Read-Host 
+    if ($confirm.ToUpper().StartsWith("Y"))
+    {
+    return $true
+    }
+    return $false
+}
+
+function GetElasticsearchInstallPath
+{
+    param
+    (
+    [string] $serviceName
+    )
+
+    $output = Get-WmiObject win32_service | ?{$_.Name -like $serviceName} | select PathName
+
+    if($output)
+    {
+        $pathTokens = $output.PathName -split '"'
+        $servicePath = if ($pathTokens.Length -gt 1) { $pathTokens[1] } else { ($output.PathName -split ' ')[0] }
+        $servicePath = Split-Path -Path $servicePath
+    }
+
+    return $servicePath
+}
+
+if(-not (IsCurrentUserAdmin))
+{
+    Write-Error "Run the script with Admin privileges"
+    Exit
+}
+
+$message = "This can be fatal!!. It will delete current indexed data for all the collections. Do you want to continue - Yes(Y) or No(N)? "
+
+ImportSQLModule
+
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+
+if(IsResetConfirm($message))
+{
+    try
+    {
+        $SqlFullPath = Join-Path $PSScriptRoot -ChildPath 'SqlScripts\EnableSearchOnOriginalContent.sql'
+    Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName  -Verbose -Variable $Params
+    Write-Host "Successfully enabled Feature flags to support Chinese characters!!" -ForegroundColor Green
+    # Getting the install path of the Team Foundation Server
+    $serviceName = 'elasticsearch-service-x64'
+    
+    $servicePath = GetElasticsearchInstallPath($serviceName)
+
+    if(-not $servicePath)
+    {
+            $ESIndexLocation = $env:SEARCH_ES_INDEX_PATH
+            if(-not $ESIndexLocation)
+            {
+                Remove-Item -Recurse -Force -Path $ESIndexLocation
+                Write-Host "Cleaned up the index folder $ESIndexLocation" -ForegroundColor Green
+            }
+            else
+            {
+                Write-Host "Could not find ElasticSearch service or data, may be Search hasn't configured yet. Exiting" -ForegroundColor Yellow
+            }
+    }
+    else
+    {
+        [System.ENVIRONMENT]::CurrentDirectory = $pwd
+        Write-Host "Found ElasticSearch at $servicePath" -ForegroundColor Green
+        Push-Location
+
+        cd $servicePath
+        $outputService = .\elasticsearch-service.bat stop 
+        Write-Host $outputService -ForegroundColor Yellow
+        if($outputService -like '*failed*')
+        {
+            Write-Host "Failed to stop service, may be Search hasn't configured yet. Exiting" -ForegroundColor Yellow
+        }
+        else
+        {
+            $ESIndexLocation = $env:SEARCH_ES_INDEX_PATH
+            Remove-Item -Recurse -Force -Path $ESIndexLocation
+
+            Write-Host "Cleaned up the index folder $ESIndexLocation" -ForegroundColor Green
+
+            $outputService = .\elasticsearch-service.bat remove
+            Write-Host $outputService -ForegroundColor Yellow
+        }
+
+        Write-Host "Please remove search service from the AzureDevops admin console and reconfigure Search" -ForegroundColor Green
+        Pop-Location 
+    }
+    }
+    catch
+    {
+        Write-Warning " Something went wrong. Exiting! ElasticSearch was not reset. Please clean it up manually or reach out to support team."
+    }
+    
+}
+else
+{
+    Write-Warning "Exiting! ElasticSearch was not reset.Please clean it up manually or reach out to support team."
+}

--- a/ADO_Server_Diagnostics_2025/ExcludedTfvcFoldersForIndexing.ps1
+++ b/ADO_Server_Diagnostics_2025/ExcludedTfvcFoldersForIndexing.ps1
@@ -1,0 +1,87 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True, Position=0, HelpMessage="The Server Instance against which the script is to run.")]
+    [string]$SQLServerInstance,
+   
+    [Parameter(Mandatory=$True, Position=1, HelpMessage="Collection Database name.")]
+    [string]$CollectionDatabaseName,
+
+	[Parameter(Mandatory=$True, Position=2, HelpMessage="Configuration DB")]
+    [string]$ConfigurationDatabaseName,
+	
+    [Parameter(Mandatory=$True, Position=3, HelpMessage="Enter the Collection Name here.")]
+    [string]$CollectionName,
+    
+	[Parameter(Mandatory=$True, Position=4, HelpMessage="Enter operation type 'Add' for adding more folder(s), 'Remove' for removing folder(s) from exclusion list, 'Delete' for deleting all the folders in the list, 'Fetch' for fetching list of folders present in exclusion list.")]
+    [string]$OperationType
+)
+
+Import-Module .\Common.psm1 -Force
+
+function AddExcludedFolders
+{
+	$foldersList = Read-Host 'Specify comma separated list of folders to Exclude from Indexing'
+	$Params = "CollectionId='$CollectionID'", "FolderPaths='$foldersList'"
+	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\AddFoldersInExclusionList.sql'
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	Write-Host "Added Given folders to Indexing Exclusion list" -ForegroundColor Yellow
+}
+
+function FetchExcludedFoldersList
+{
+	$Params = "CollectionId='$CollectionID'"
+	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\FetchFoldersInExclusionList.sql'
+	$QueryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	
+	$ExcludedFoldersList = $QueryResults | Select-object -ExpandProperty ExcludedFolders	
+	Write-Host "Folders present in Indexing Exclusion list are: '$ExcludedFoldersList'" -ForegroundColor Yellow
+}
+
+function RemoveFoldersFromExclusionList
+{
+	$foldersList = Read-Host 'Specify comma separated list of folders to remove from Indexing Exclusion list'
+	$Params = "CollectionId='$CollectionID'", "FolderPaths='$foldersList'"
+	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\RemoveFoldersFromExclusionList.sql'
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	Write-Host "Removed given folders from Indexing Exclusion list" -ForegroundColor Yellow
+}
+
+function DeleteAllExcludedFolders
+{
+	$Params = "CollectionId='$CollectionID'"
+	$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\TfvcExcludedFolders\DeleteAllFoldersInExclusionList.sql'
+	Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $Params
+	Write-Host "Deleted all folders from Indexing Exclusion list" -ForegroundColor Yellow
+}
+
+[System.ENVIRONMENT]::CurrentDirectory = $PWD
+Push-Location
+ImportSQLModule
+
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+
+switch ($OperationType)
+{
+    "Add" 
+        {
+            Write-Host "Adding folders to exclusion list..." -ForegroundColor Green
+            AddExcludedFolders
+        }
+    "Fetch" 
+        {
+            Write-Host "Fetching folders present in exclusion list..." -ForegroundColor Green
+            FetchExcludedFoldersList
+        }
+    "Remove"
+        {
+            Write-Host "Removing given folders from exclusion list..." -ForegroundColor Green
+            RemoveFoldersFromExclusionList
+        }
+    "Delete"
+		{
+			Write-Host "Deleting all the folders from exclusion list..." -ForegroundColor Green
+			DeleteAllExcludedFolders
+		}
+}
+
+Pop-Location

--- a/ADO_Server_Diagnostics_2025/ExtensionInstallIndexingStatus.ps1
+++ b/ADO_Server_Diagnostics_2025/ExtensionInstallIndexingStatus.ps1
@@ -1,0 +1,273 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True, Position=0, HelpMessage="The SQL Server Instance against which the script is to run.")]
+    [string]$SQLServerInstance,
+   
+    [Parameter(Mandatory=$True, Position=1, HelpMessage="Collection Database name.")]
+    [string]$CollectionDatabaseName,
+    
+    [Parameter(Mandatory=$True, Position=2, HelpMessage="Configuration DB")]
+    [string]$ConfigurationDatabaseName,
+   
+    [Parameter(Mandatory=$True, Position=3, HelpMessage="Enter the Collection Name here.")]
+    [string]$CollectionName,
+    
+    [Parameter(Mandatory=$True, Position=4, HelpMessage="Enter the days since last indexing was triggered for this collection")]
+    [string]$Days,
+    
+    [Parameter(Mandatory=$False, Position=5, HelpMessage="Extension install indexing state for Code, WorkItem, Wiki or All")]
+    [string]$EntityType = "All"
+)
+
+Import-Module .\Common.psm1 -Force
+
+# Fetches the Code Extension install indexing status.
+function CodeExtensionInstallIndexingStatus
+{
+    # Validating if the collection has code extension installed.
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexed")
+    {
+        #Gets the result of the Code Extension AccountFaultIn job
+        $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeAccountFaultInResult.sql'
+        $queryResults = Invoke-Sqlcmd -InputFile "$PWD\SqlScripts\CodeAccountFaultInResult.sql" -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+    
+        if($queryResults)
+        {
+            $resultState = $queryResults  | Select-object  -ExpandProperty  Result
+            $resultMessage = $queryResults  | Select-object  -ExpandProperty  ResultMessage
+
+            if($resultState -eq 0)
+            {
+                Write-Host "Collection Code indexing was triggered successfully" -ForegroundColor Yellow
+            }
+            else
+            {
+                Write-Error "Collection Code indexing was not triggered with this message: $resultMessage"
+            }
+
+            # Gets the count of repositories for which the code indexing has completed.
+            $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CountCodeIndexingCompleted.sql'
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+            $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
+
+            if($indexingCompletedRepositoryCount -gt 0)
+            {
+                Write-Host "Code Repositories completed indexing: '$indexingCompletedRepositoryCount'" -ForegroundColor Yellow
+            }
+            else
+            {
+                Write-Host "No Code repositories completed fresh indexing in this collection in last $Days days" -ForegroundColor Cyan
+            }
+        
+            # Gets the data for repositories which are still inprogress.
+            $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeBulkIndexingInProgressRepositoryCount.sql'
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params
+            $CodeBulkIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ItemArray
+
+            if($CodeBulkIndexingInProgressRepositoryCount -gt 0)
+            {
+                Write-Host "Status of code indexing:" -ForegroundColor Yellow
+                Write-Host "Repository Id                         | Repository Name" -ForegroundColor Green
+ 
+                foreach($row in $queryResults)
+                {
+                    Write-Host "$($row.TfsEntityId)  | $($row.RepositoryIndexingInProgress)" -ForegroundColor Yellow
+                }
+            }
+            else
+            {
+                Write-Host "No code repositories are currently in indexing state." -ForegroundColor Cyan
+            }
+        }
+        else
+        {
+            Write-Host "No code indexing job found for Configuration/Extension installs. Try a day range near to the date of configuration/extension install"
+        }
+    }
+    else
+    {
+        Write-Host "The code search extension is disabled for this account. Install the extension and then try again." -ForegroundColor DarkYellow
+    }
+}
+
+
+function WorkItemExtensionInstallIndexingStatus
+{
+    # Validating if the collection has workitem extension installed.
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWorkItem")
+    {
+        #Gets the result of the Code Extension AccountFaultIn job
+        $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemAccountFaultInResult.sql'
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+    
+        if($queryResults)
+        {
+            $resultState = $queryResults  | Select-object  -ExpandProperty  Result
+            $resultMessage = $queryResults  | Select-object  -ExpandProperty  ResultMessage
+
+            if($resultState -eq 0)
+            {
+                Write-Host "Collection WorkItem indexing was triggered successfully" -ForegroundColor Yellow
+            }
+            else
+            {
+                Write-Error "Collection WorkItem indexing was not triggered with this message: $resultMessage"
+            }
+
+            # Gets the count of repositories for which the indexing has completed.
+            $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CountWorkItemIndexingCompleted.sql'
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName -Variable $indexingCompletedQueryParams
+            $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
+
+            if($indexingCompletedRepositoryCount -gt 0)
+            {
+                Write-Host "WorkItem Projects completed indexing: '$indexingCompletedRepositoryCount'" -ForegroundColor Yellow
+            }
+            else
+            {
+                Write-Host "No WorkItem Projects completed fresh indexing in this collection in last $Days days" -ForegroundColor Cyan
+            }
+        
+            # Gets the data for projects with workitem indexing still inprogress.
+            $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WorkItemIndexingInProgressRepositoryCount.sql'
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params
+            $WorkItemIndexingInProgressRepositoryCount = $queryResults  | Select-object  -ExpandProperty  ItemArray
+
+            if($WorkItemIndexingInProgressRepositoryCount -gt 0)
+            {
+                Write-Host "Status of WorkItem indexing:" -ForegroundColor Yellow
+                Write-Host "Project Id                         | Project Name" -ForegroundColor Green
+ 
+                foreach($row in $queryResults)
+                {
+                    Write-Host "$($row.TfsEntityId)  | $($row.ProjectWorkItemIndexingInProgress)" -ForegroundColor Yellow
+                }
+            }
+            else
+            {
+                Write-Host "No workitem projects are currently in indexing state." -ForegroundColor Cyan
+            }
+        }
+        else
+        {
+            Write-Host "No workitem projects indexing job found for Configuration/Extension installs. Try a day range near to the date of configuration/extension install"
+        }
+    }
+    else
+    {
+        Write-Host "The workitem search extension is disabled for this account. Install the extension and then try again." -ForegroundColor DarkYellow
+    }
+}
+
+# Fetches the Wiki Extension install indexing status.
+function WikiExtensionInstallIndexingStatus
+{
+    # Validating if the collection has wiki search extension installed.
+    if(IsExtensionInstalled $SQLServerInstance $CollectionDatabaseName "IsCollectionIndexedForWiki")
+    {
+        #Gets the result of the Wiki Extension AccountFaultIn job
+        $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiAccountFaultInResult.sql'
+        $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $ConfigurationDatabaseName  -Verbose -Variable $Params
+
+        if($queryResults)
+        {
+            $resultState = $queryResults  | Select-object  -ExpandProperty  Result
+            $resultMessage = $queryResults  | Select-object  -ExpandProperty  ResultMessage
+
+            if($resultState -eq 0)
+            {
+                Write-Host "Collection Wiki indexing was triggered successfully" -ForegroundColor Yellow
+            }
+            else
+            {
+                Write-Error "Collection Wiki indexing was not triggered with this message: $resultMessage"
+            }
+
+            # Gets the count of repositories for which the wiki indexing has completed.
+            $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingCompletedActivity.sql'
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $indexingCompletedQueryParams
+            $indexingCompletedRepositoryCount = $queryResults  | Select-object  -ExpandProperty  IndexingCompletedCount
+
+            if($indexingCompletedRepositoryCount -gt 0)
+            {
+                Write-Host "Wiki Repositories completed indexing: '$indexingCompletedRepositoryCount'" -ForegroundColor Yellow
+            }
+            else
+            {
+                Write-Host "No Wiki repositories completed fresh indexing in this collection in last $Days days" -ForegroundColor Cyan
+            }
+
+            # Gets the data for repositories which are still inprogress.
+            $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\WikiIndexingInProgressRepositories.sql'
+            $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName  -Verbose -Variable $Params
+            $WikiIndexingInProgressRepositories = $queryResults  | Select-object  -ExpandProperty  ItemArray
+
+            if($WikiIndexingInProgressRepositories -gt 0)
+            {
+                Write-Host "Status of wiki indexing:" -ForegroundColor Yellow
+                Write-Host "Repository Id                         | Repository Name" -ForegroundColor Green
+ 
+                foreach($row in $queryResults)
+                {
+                    Write-Host "$($row.TfsEntityId)  | $($row.RepositoryIndexingInProgress)" -ForegroundColor Yellow
+                }
+            }
+            else
+            {
+                Write-Host "No wiki repositories are currently in indexing state." -ForegroundColor Cyan
+            }
+        }
+        else
+        {
+            Write-Host "No wiki indexing job found for Configuration/Extension installs. Try a day range near to the date of configuration/extension install"
+        }
+    }
+    else
+    {
+        Write-Host "The wiki search extension is disabled for this account. Install the extension and then try again." -ForegroundColor DarkYellow
+    }
+}
+
+Write-Host "Checking indexing state for last $Days days" -ForegroundColor Green
+
+[System.ENVIRONMENT]::CurrentDirectory = $PWD
+Push-Location
+ImportSQLModule
+
+# Checking for valid Collection Name.
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+
+$Params = "CollectionId='$CollectionID'" 
+$indexingCompletedQueryParams = "DaysAgo='$Days'","CollectionId='$CollectionID'"
+
+switch ($EntityType)
+{
+    "All" 
+        {
+            Write-Host "Fetching Indexing Activity for Code, WorkItem and Wiki..." -ForegroundColor Green
+            CodeExtensionInstallIndexingStatus
+            WorkItemExtensionInstallIndexingStatus
+            WikiExtensionInstallIndexingStatus
+        }
+    "WorkItem" 
+        {
+            Write-Host "Fetching Indexing Activity for WorkItem..." -ForegroundColor Green
+            WorkItemExtensionInstallIndexingStatus
+        }
+    "Code"
+        {
+            Write-Host "Fetching Indexing Activity for Code..." -ForegroundColor Green
+            CodeExtensionInstallIndexingStatus
+        }
+    "Wiki"
+        {
+            Write-Host "Fetching Indexing Activity for Wiki..." -ForegroundColor Green
+            WikiExtensionInstallIndexingStatus
+        }
+    default 
+        {
+            Write-Host "Enter a valid EntityType i.e. Code or WorkItem or Wiki or All" -ForegroundColor Red
+        }
+}
+
+Pop-Location

--- a/ADO_Server_Diagnostics_2025/FixIndexingIndexName.ps1
+++ b/ADO_Server_Diagnostics_2025/FixIndexingIndexName.ps1
@@ -1,0 +1,30 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True, Position=0, HelpMessage="The Server Instance against which the script is to run.")]
+    [string]$SQLServerInstance,
+   
+    [Parameter(Mandatory=$True, Position=1, HelpMessage="Collection Database name.")]
+    [string]$CollectionDatabaseName,
+    
+    [Parameter(Mandatory=$True, Position=2, HelpMessage="Configuration DB")]
+    [string]$ConfigurationDatabaseName,
+   
+    [Parameter(Mandatory=$True, Position=3, HelpMessage="Enter the Collection Name here.")]
+    [string]$CollectionName
+)
+
+Import-Module .\Common.psm1 -Force
+
+[System.ENVIRONMENT]::CurrentDirectory = $PWD
+Push-Location
+ImportSQLModule
+
+$CollectionID = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $CollectionName
+
+# Fix the index name in all repo indexing units
+$fixIndexingIndexNameParams = "CollectionId='$CollectionID'"
+$SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\FixIndexingIndexName.sql'
+Invoke-Sqlcmd -InputFile $SqlFullPath -serverInstance $SQLServerInstance -database $CollectionDatabaseName -Variable $fixIndexingIndexNameParams
+Write-Host "Fixed the indexing index name in all repo indexing units" -ForegroundColor Cyan
+
+Pop-Location

--- a/ADO_Server_Diagnostics_2025/GetCollectionReIndexingActivityStatus.ps1
+++ b/ADO_Server_Diagnostics_2025/GetCollectionReIndexingActivityStatus.ps1
@@ -1,0 +1,66 @@
+﻿#Display collection indexing status for a given collection.
+
+[CmdletBinding()]
+Param(
+    
+    [Parameter(Mandatory=$True, Position=0, HelpMessage="Collection name.")]
+    [String]
+    $userCollection,
+
+    [Parameter(Mandatory=$True, Position=1, HelpMessage="The SQL Server instance.")]
+    [String]
+    $SQLServerInstance,
+    
+    [Parameter(Mandatory=$True, Position=2, HelpMessage="Configuration Database name.")]
+    [String]
+    $ConfigurationdatabaseName,
+    
+    [Parameter(Mandatory=$True, Position=3, HelpMessage="Collection database name.")]
+    [String]
+    $CollectionDatabaseName,
+
+    [Parameter(Mandatory=$False, Position=4, HelpMessage="Location of previous Elasticsearch aggregation output.")]
+    [String]
+    $Source,
+
+    [Parameter(Mandatory=$False, Position=5, HelpMessage="URI for Elasticsearch instance.")]
+    [String]
+    $Uri
+)
+
+
+function getCollectionIndexingStatus
+{
+    if(!$ConfigurationDatabaseName -or !$CollectionDatabaseName)
+    {
+        Write-Host "Please enter ConfigurationDatabaseName and CollectionDatabaseName"
+        return
+    }
+    Import-Module .\Common.psm1 -Force
+    $collectionId = ValidateCollectionName $SQLServerInstance $ConfigurationDatabaseName $userCollection
+    $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeIndexingCompletedCount.sql'
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName
+    $completed =  $queryResults.BulkIndexingCompletedCount
+    Write-Host "No of repositories completed: $completed"
+                                              
+    $SqlFullPath = Join-Path $PWD -ChildPath 'SqlScripts\CodeIndexingInProgressRepositories.sql'
+    $queryResults = Invoke-Sqlcmd -InputFile $SqlFullPath -ServerInstance $SQLServerInstance -Database $collectionDatabaseName
+    $inProgress = $queryResults.Length
+    Write-Host "Repositories InProgress: $inProgress"
+    if($inProgress -gt 0)
+    {
+        Write-Host "`nInProgress Status:"
+    }
+    foreach($repository in $queryResults)
+    {
+         $project = $repository.ProjectName
+         $repository = $repository.RepositoryName
+         Write-Host "`nProject: $project Repository: $repository"
+         if($Source -and $Uri)
+         {
+              &.\GetRepositoryReIndexingActivityStatus.ps1 $userCollection $project $repository $Source $Uri
+         }         
+    }
+}
+
+getCollectionIndexingStatus


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 1 of 20).

Files:
- CleanUpShardDetails.ps1
- EnableSearchForChineseCharacters.ps1
- ExcludedTfvcFoldersForIndexing.ps1
- ExtensionInstallIndexingStatus.ps1
- FixIndexingIndexName.ps1
- GetCollectionReIndexingActivityStatus.ps1
