### PR TITLE
Add ADO Server 2025 scripts (part 4 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobHistoryData.sql
+++ b/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobHistoryData.sql
@@ -1,0 +1,20 @@
+/*
+This script gets the job history data.
+*/
+
+Declare @Days int = $(DaysAgo);
+
+SELECT [JobSource]
+      ,[JobId]
+      ,[QueueTime]
+      ,[StartTime]
+      ,[EndTime]
+      ,[Result]
+      ,[ResultMessage]
+  FROM tbl_JobHistory
+  where QueueTime >  DATEADD(DAY, -@Days, GETUTCDATE()) and 
+  (JobId = '02F271F3-0D40-4FA0-9328-C77EBCA59B6F' or JobId = '03CEE4B8-ECC1-4E57-95CE-FA430FE0DBFB' or JobId = '27B11FD5-1DA5-48B4-A732-761CE99F5A5F'
+  or ResultMessage like '%completed with status%'
+  or ResultMessage like '%back to Pending state with requeueDelay%'
+  or ResultMessage like '%Installed extension%')
+  order by StartTime desc

--- a/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobQueueData.sql
+++ b/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobQueueData.sql
@@ -1,0 +1,7 @@
+/*
+This script gets the job queue status for the Account Fault-In jobs that trigger indexing.
+*/
+
+SELECT QueueTime, JobSource, JobId, JobState
+FROM tbl_JobQueue
+where JobId = '02F271F3-0D40-4FA0-9328-C77EBCA59B6F' or JobId = '03CEE4B8-ECC1-4E57-95CE-FA430FE0DBFB' or JobId = '27B11FD5-1DA5-48B4-A732-761CE99F5A5F'

--- a/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobThrottlingData.sql
+++ b/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobThrottlingData.sql
@@ -1,0 +1,8 @@
+/*
+This script gets the job throttling settings.
+*/
+
+SELECT ParentPath, ChildItem, RegValue
+FROM tbl_RegistryItems
+where PartitionId > 0 and 
+(ChildItem = 'JobQueueControllerCpuHealthJobThrottleCount\' or ChildItem = 'JobQueueControllerCpuHealthThreshold\')

--- a/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/SearchConnectionUrlData.sql
+++ b/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/SearchConnectionUrlData.sql
@@ -1,0 +1,8 @@
+/*
+This script gets the configured Search (Elasticsearch) connection URL string.
+*/
+
+SELECT ParentPath, ChildItem, RegValue
+FROM tbl_RegistryItems
+where PartitionId > 0 and 
+ChildItem like '%SearchPlatformConnectionString%'

--- a/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/SearchRegistryData.sql
+++ b/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/SearchRegistryData.sql
@@ -1,0 +1,8 @@
+/*
+This script gets the Search related registry settings.
+*/
+
+SELECT ParentPath, ChildItem, RegValue
+FROM tbl_RegistryItems
+where PartitionId > 0 and 
+ParentPath like '%Search%'

--- a/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/ServiceHostData.sql
+++ b/ADO_Server_Diagnostics_2025/SearchDiagnostics/ConfigurationDBDiagnosticScripts/ServiceHostData.sql
@@ -1,0 +1,11 @@
+/*
+This script gets the Service Host table data.
+*/
+
+SELECT [HostId]
+      ,[ParentHostId]
+      ,[Name]
+      ,[Status]
+      ,[HostType]
+      ,[ServiceLevel]
+FROM tbl_ServiceHost


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 4 of 20).

Files:
- SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobHistoryData.sql
- SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobQueueData.sql
- SearchDiagnostics/ConfigurationDBDiagnosticScripts/JobThrottlingData.sql
- SearchDiagnostics/ConfigurationDBDiagnosticScripts/SearchConnectionUrlData.sql
- SearchDiagnostics/ConfigurationDBDiagnosticScripts/SearchRegistryData.sql
- SearchDiagnostics/ConfigurationDBDiagnosticScripts/ServiceHostData.sql
