### PR TITLE
Add ADO Server 2025 scripts (part 6 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/SqlScripts/AddRepositoryUpdateMetadataChangeEvent.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/AddRepositoryUpdateMetadataChangeEvent.sql
@@ -1,0 +1,65 @@
+/** This sql script is to Add the IndexingUnitChangeEvent to Set Indexing State for the repository.
+-- The script needs to be executed on the Collection DB of the collection to which the repository belongs to.
+-- ** !! POST running this script, please run the "QueuePeriodicMaintenanceJob" script against the Configuration DB. !! **/
+
+DECLARE @RepositoryName nvarchar(max) = $(RepositoryName)
+DECLARE @ProjectName nvarchar(max) = $(ProjectName)
+DECLARE @CollectionId uniqueidentifier = $(CollectionId)
+DECLARE @IndexingState nvarchar(50) = $(IndexingState)
+
+DECLARE @PartitionID int
+SELECT @PartitionID = PartitionId from [dbo].[tbl_DatabasePartitionMap] where ServiceHostId = @CollectionId
+
+IF (@PartitionID <= 0)
+    BEGIN
+	    PRINT N'Not updating Metadata of Repository. Collection not indexed.'
+	    RETURN
+    END
+
+DECLARE @ProjectIndexingUnitId int
+SELECT @ProjectIndexingUnitId = IndexingUnitId from Search.tbl_IndexingUnit
+    WHERE PartitionId = @PartitionID
+    AND TFSEntityAttributes Like '%<ProjectName>'+@ProjectName+'</ProjectName>%'
+    AND IndexingUnitType Like '%Project%'
+    AND EntityType Like 'Code'
+
+DECLARE @RepositoryIndexingUnitId int
+SELECT @RepositoryIndexingUnitId = IndexingUnitId from Search.tbl_IndexingUnit
+    WHERE PartitionId = @PartitionID
+    AND ParentUnitId = @ProjectIndexingUnitId
+    AND TFSEntityAttributes Like '%<RepositoryName>'+@RepositoryName+'</RepositoryName>%'
+    AND IndexingUnitType Like '%Repository%'
+
+IF (@ProjectIndexingUnitId is null OR @RepositoryIndexingUnitId is null)
+    BEGIN
+	    PRINT N'We dont have this project/repository indexed.'
+	    RETURN
+    END
+
+DECLARE @DisabledState nvarchar(20)
+IF (@IndexingState = 'Off')
+    BEGIN
+	    SET @DisabledState = 'True'
+    END
+ELSE IF (@IndexingState = 'On')
+    BEGIN
+	    SET @DisabledState = 'False'
+    END
+ELSE
+    BEGIN
+	    PRINT N'Unknown Indexing State. Please try passing value as "On" or "Off"'
+	    RETURN
+    END
+
+
+DECLARE @ChangeData nvarchar(max) = '<ChangeEventData i:type="UpdateMetadataEventData" xmlns="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Trigger>None</Trigger><CorrelationId>$CorrelationId</CorrelationId><UpdatedData>$DisabledState</UpdatedData><UpdateType>SetIndexingState</UpdateType></ChangeEventData>'
+SET @ChangeData = REPLACE(@ChangeData, '$DisabledState', @DisabledState)
+SET @ChangeData = REPLACE(@ChangeData, '$CorrelationId', NEWID())
+
+DECLARE @Prerequisites nvarchar(max)
+SET @Prerequisites = '<IndexingUnitChangeEventPrerequisites i:nil="true" xmlns="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"/>'
+
+DECLARE @ItemList Search.typ_IndexingUnitChangeEventDescriptorV3;
+INSERT INTO @ItemList values (@RepositoryIndexingUnitId, 'UpdateMetadata', @ChangeData, NULL, 'Pending', 0, @Prerequisites, NULL, 0);
+
+EXEC Search.prc_AddEntryForIndexingUnitChangeEvent @PartitionID, @ItemList

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CleanUpCollectionIndexingState.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CleanUpCollectionIndexingState.sql
@@ -1,0 +1,86 @@
+-- This script cleans up all the tables/entries which has the indexing state of given entity type and given collection in collection database.
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @EntityTypeString VARCHAR(32) = $(EntityTypeString);
+Declare @EntityTypeInt TINYINT = $(EntityTypeInt);
+
+DECLARE @partitionID VARCHAR(50)
+SELECT @partitionID = PartitionID FROM [dbo].[tbl_DatabasePartitionMap] WHERE ServiceHostId = @CollectionId
+
+IF (OBJECT_ID(N'Search.tbl_ResourceLockTable') IS NOT NULL)
+BEGIN
+    DELETE FROM [Search].[tbl_ResourceLockTable]
+        WHERE LeaseId IN (
+            SELECT DISTINCT(IUCE.LeaseId) FROM [Search].[tbl_IndexingUnitChangeEvent] IUCE INNER JOIN [Search].[tbl_IndexingUnit] IU
+                ON IUCE.IndexingUnitId = IU.IndexingUnitId AND IU.EntityType = @EntityTypeString AND IUCE.PartitionId = @partitionID)
+            AND PartitionId = @partitionID
+END
+
+DELETE IUCE FROM [Search].[tbl_IndexingUnitChangeEvent] IUCE INNER JOIN [Search].[tbl_IndexingUnit] IU ON IUCE.IndexingUnitId = IU.IndexingUnitId AND IU.EntityType = @EntityTypeString AND IUCE.PartitionId = @partitionID
+
+IF (OBJECT_ID(N'Search.tbl_ItemLevelFailures') IS NOT NULL)
+BEGIN
+    DELETE ILF FROM [Search].[tbl_ItemLevelFailures] ILF INNER JOIN [Search].[tbl_IndexingUnit] IU ON ILF.IndexingUnitId = IU.IndexingUnitId AND IU.EntityType = @EntityTypeString AND ILF.PartitionId = @partitionID
+END
+
+IF (OBJECT_ID(N'Search.tbl_IndexingUnitIndexingInformation') IS NOT NULL)
+BEGIN
+    DELETE FROM [Search].[tbl_IndexingUnitIndexingInformation] WHERE EntityType = @EntityTypeInt AND PartitionId = @partitionID
+END
+
+IF (OBJECT_ID(N'Search.tbl_JobYield') IS NOT NULL)
+BEGIN
+    DELETE FROM [Search].[tbl_JobYield] WHERE EntityType = @EntityTypeString AND PartitionId = @partitionID
+END
+
+IF (OBJECT_ID(N'Search.tbl_TreeStore') IS NOT NULL)
+BEGIN
+    DELETE FROM [Search].[tbl_TreeStore] WHERE EntityType = @EntityTypeString AND PartitionId = @partitionID
+END
+
+IF (@EntityTypeString = 'Code')
+BEGIN
+    IF (OBJECT_ID(N'Search.tbl_CustomRepositoryInfo') IS NOT NULL)
+    BEGIN
+        DELETE FROM [Search].[tbl_CustomRepositoryInfo] WHERE PartitionId = @partitionID
+    END
+    
+    IF (OBJECT_ID(N'Search.tbl_DisabledFiles') IS NOT NULL)
+    BEGIN
+        DELETE FROM [Search].[tbl_DisabledFiles] WHERE PartitionId = @partitionID
+    END
+    
+    IF (OBJECT_ID(N'Search.tbl_FileMetadataStore') IS NOT NULL)
+    BEGIN
+        DELETE FROM [Search].[tbl_FileMetadataStore] WHERE PartitionId = @partitionID
+    END
+    
+    IF (OBJECT_ID(N'Search.tbl_TempFileMetadataStore') IS NOT NULL)
+    BEGIN
+        DELETE FROM [Search].[tbl_TempFileMetadataStore] WHERE PartitionId = @partitionID
+    END
+END
+
+IF (@EntityTypeString = 'Wiki')
+BEGIN
+    IF (OBJECT_ID(N'Search.tbl_IndexingUnitWikis') IS NOT NULL)
+    BEGIN
+        DELETE FROM [Search].[tbl_IndexingUnitWikis] WHERE PartitionId = @partitionID
+    END
+END
+
+IF (@EntityTypeString = 'WorkItem')
+BEGIN
+    IF (OBJECT_ID(N'Search.tbl_ClassificationNode') IS NOT NULL)
+    BEGIN
+        DELETE FROM [Search].[tbl_ClassificationNode] WHERE PartitionId = @partitionID
+    END
+END
+
+DELETE FROM [Search].[tbl_IndexingUnit] WHERE EntityType = @EntityTypeString AND PartitionId = @partitionID
+
+DECLARE @UninstallInProgressRegKey VARCHAR(MAX) = '#\Service\ALMSearch\Settings\IsExtensionOperationInProgress\' + @EntityTypeString + '\Uninstalled\';
+EXEC prc_SetRegistryValue @partitionID, @UninstallInProgressRegKey, @value = NULL
+
+DECLARE @InstallInProgressRegKey VARCHAR(MAX) = '#\Service\ALMSearch\Settings\IsExtensionOperationInProgress\' + @EntityTypeString + '\Installed\';
+EXEC prc_SetRegistryValue @partitionID, @InstallInProgressRegKey, @value = NULL

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CleanUpCollectionIndexingState_IndexDelete.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CleanUpCollectionIndexingState_IndexDelete.sql
@@ -1,0 +1,12 @@
+/**
+This script cleans up all the tables which has the state of indexing for all the indexing units of the Collection. 
+**/
+TRUNCATE TABLE [Search].[tbl_ClassificationNode]
+TRUNCATE TABLE [Search].[tbl_DisabledFiles]
+TRUNCATE TABLE [Search].[tbl_IndexingUnit]
+TRUNCATE TABLE [Search].[tbl_IndexingUnitIndexingInformation]
+TRUNCATE TABLE [Search].[tbl_IndexingUnitChangeEvent]
+TRUNCATE TABLE [Search].[tbl_IndexingUnitWikis]
+TRUNCATE TABLE [Search].[tbl_ItemLevelFailures]
+TRUNCATE TABLE [Search].[tbl_JobYield]
+TRUNCATE TABLE [Search].[tbl_ResourceLockTable]

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CleanUpShardDetailsTable.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CleanUpShardDetailsTable.sql
@@ -1,0 +1,4 @@
+﻿/**
+This script cleans up all the entries in the shard details table. 
+**/
+TRUNCATE TABLE [Search].[tbl_ShardDetails]

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeAccountFaultInResult.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeAccountFaultInResult.sql
@@ -1,0 +1,10 @@
+/*
+Gets the result of the AccountFaultIn Job for the collection
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+SELECT Top 1 Result, ResultMessage 
+	FROM tbl_JobHistory
+	WHERE JobId = '02F271F3-0D40-4FA0-9328-C77EBCA59B6F'
+	AND JobSource = @CollectionId 
+	ORDER BY StartTime DESC

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeBulkIndexingActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeBulkIndexingActivity.sql
@@ -1,0 +1,13 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of repositories for which the Fresh Indexing(new repository) has already completed.
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+Select Count(Distinct(JobId)) as BulkIndexingCompletedCount from tbl_JobHistory
+where 
+JobSource = @CollectionId
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and ( ResultMessage like '%Git_Repository%Branches for BulkIndexing = (refs/heads%' or ResultMessage like '%Tfvc_Repository%BeginBulkIndex%Completed pipeline execution for IndexingUnit%EntityType: Code%')


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 6 of 20).

Files:
- SqlScripts/AddRepositoryUpdateMetadataChangeEvent.sql
- SqlScripts/CleanUpCollectionIndexingState_IndexDelete.sql
- SqlScripts/CleanUpCollectionIndexingState.sql
- SqlScripts/CleanUpShardDetailsTable.sql
- SqlScripts/CodeAccountFaultInResult.sql
- SqlScripts/CodeBulkIndexingActivity.sql
