### PR TITLE
Add ADO Server 2025 scripts (part 7 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeBulkIndexingInProgressActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeBulkIndexingInProgressActivity.sql
@@ -1,0 +1,20 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of repositories for which the bulk indexing of a git/tfvc repository is in Progress.
+*/
+SELECT Count(TfsEntityId) AS BulkIndexingInProgressCount
+		FROM Search.tbl_IndexingUnit AS IU join 
+		Search.tbl_IndexingUnitChangeEvent  as IUCE ON IU.IndexingUnitId = IUCE.IndexingUnitId and IU.PartitionId = IUCE.PartitionId
+		where IUCE.ChangeType = 'BeginBulkIndex' AND IUCE.State in ('InProgress', 'Pending', 'Queued', 'FailedAndRetry')
+		AND IU.IndexingUnitType IN ('TFVC_Repository', 'Git_Repository')
+		AND IU.EntityType = 'Code'
+		AND IU.PartitionId > 0
+		AND IUCE.PartitionId > 0
+	    AND ((IndexingUnitType = 'Git_Repository'
+			AND CAST(Properties AS xml).exist('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+			declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+					  (/NS:IndexingProperties/NS:BranchIndexInfo/AS:KeyValueOfstringGitBranchIndexInfoRWfTSrgf/AS:Value/NS:LastIndexedCommitId[text() = "0000000000000000000000000000000000000000"])') = 1)
+		   OR (IndexingUnitType = 'TFVC_Repository'
+			   AND CAST(Properties AS xml).exist('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+			declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+					  (/NS:IndexingProperties/NS:LastIndexedChangeSetId[text() = "-1"])') = 1) )

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeBulkIndexingInProgressRepositoryCount.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeBulkIndexingInProgressRepositoryCount.sql
@@ -1,0 +1,12 @@
+/*
+Gets the per repository status of indexing
+*/
+SELECT DISTINCT(TfsEntityId), substring(TfsEntityAttributes, CHARINDEX('<RepositoryName>', TFSEntityAttributes) + 16,
+ (CHARINDEX('</RepositoryName>', TFSEntityAttributes) - (CHARINDEX('<RepositoryName>', TFSEntityAttributes) + 16)))  as RepositoryIndexingInProgress
+		FROM Search.tbl_IndexingUnit as IU join 
+		Search.tbl_IndexingUnitChangeEvent  as IUCE on IU.IndexingUnitId = IUCE.IndexingUnitId  and IU.PartitionId = IUCE.PartitionId
+		where IUCE.ChangeType = 'BeginBulkIndex' and (IUCE.ChangeData Like '%<Trigger>AccountFaultIn</Trigger>%' or IUCE.ChangeData Like '%<Trigger>ReindexCollection</Trigger>%') and IUCE.State in ('InProgress', 'Pending', 'Queued', 'FailedAndRetry')
+		and IU.IndexingUnitType in ('Tfvc_Repository', 'Git_Repository')
+		and IU.EntityType = 'Code'
+		and IU.PartitionId > 0
+		and IUCE.PartitionId > 0

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeContinuousIndexingActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeContinuousIndexingActivity.sql
@@ -1,0 +1,13 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of Continuous Indexing jobs completed in the given date range.
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+Select Count(JobId) as ContinuousIndexingCompletedCount from tbl_JobHistory
+where 
+JobSource = @CollectionId
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and ( ResultMessage like '%Git_Repository%Branches for ContinuousIndexing = (refs/heads%' or ResultMessage like '%Tfvc_Repository%%UpdateIndex%Completed pipeline execution for IndexingUnit%EntityType: Code%')

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeContinuousIndexingInProgressActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeContinuousIndexingInProgressActivity.sql
@@ -1,0 +1,15 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of Continuous Indexing jobs in progress.
+*/
+
+SELECT Count(TfsEntityId) as ContinuousIndexingInProgressCount
+		FROM Search.tbl_IndexingUnit as IU join 
+		Search.tbl_IndexingUnitChangeEvent  as IUCE on IU.IndexingUnitId = IUCE.IndexingUnitId and IU.PartitionId = IUCE.PartitionId
+		where (( IU.IndexingUnitType = 'Git_Repository' and IUCE.ChangeType = 'BeginBulkIndex' and IUCE.ChangeData like '%<Trigger>PushEventNotification</Trigger>%')
+				or
+			   ( IU.IndexingUnitType = 'TFVC_Repository' and IUCE.ChangeType = 'UpdateIndex'))
+		and IUCE.State in ('InProgress', 'Pending', 'Queued', 'FailedAndRetry')
+		and IU.EntityType = 'Code'
+		and IU.PartitionId > 0
+		and IUCE.PartitionId > 0

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeFailedIndexingActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeFailedIndexingActivity.sql
@@ -1,0 +1,13 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of Indexing jobs failed in the given date range.
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+Select Count(Distinct(JobId)) as FailedIndexingCount from tbl_JobHistory
+where 
+JobSource = @CollectionId
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and ResultMessage like '%events%completed with status Failed.%EntityType: Code%'

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeIndexingCompletedCount.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeIndexingCompletedCount.sql
@@ -1,0 +1,15 @@
+/*
+This script gets the number of repositories for which the bulk indexing of a git/tfvc repository is completed.
+*/
+SELECT count(*) as BulkIndexingCompletedCount
+		FROM Search.tbl_IndexingUnit
+		where IndexingUnitType IN ('TFVC_Repository', 'Git_Repository')
+		AND EntityType = 'Code'
+	    AND ((IndexingUnitType = 'Git_Repository'
+			AND CAST(Properties AS xml).exist('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+			declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+					  (/NS:IndexingProperties/NS:BranchIndexInfo/AS:KeyValueOfstringGitBranchIndexInfoRWfTSrgf/AS:Value/NS:LastIndexedCommitId[text() = "0000000000000000000000000000000000000000"])') <> 1)
+		   OR (IndexingUnitType = 'TFVC_Repository'
+			   AND CAST(Properties AS xml).exist('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+			declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+					  (/NS:IndexingProperties/NS:LastIndexedChangeSetId[text() = "-1"])') <> 1) )


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 7 of 20).

Files:
- SqlScripts/CodeBulkIndexingInProgressActivity.sql
- SqlScripts/CodeBulkIndexingInProgressRepositoryCount.sql
- SqlScripts/CodeContinuousIndexingActivity.sql
- SqlScripts/CodeContinuousIndexingInProgressActivity.sql
- SqlScripts/CodeFailedIndexingActivity.sql
- SqlScripts/CodeIndexingCompletedCount.sql
