### PR TITLE
Add ADO Server 2025 scripts (part 8 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/SqlScripts/CodeIndexingInProgressRepositories.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CodeIndexingInProgressRepositories.sql
@@ -1,0 +1,33 @@
+/*
+This script gets the number of repositories for which the bulk indexing of a git/tfvc repository is in progress.
+*/
+
+select cast(cast(RepoAttributes as xml).query(
+'declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+(/NS:TFSEntityAttributes/NS:RepositoryName/text())'
+) as nvarchar(max)) as RepositoryName, cast(cast(ProjectAttributes as xml).query(
+'declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+(/NS:TFSEntityAttributes/NS:ProjectName/text())'
+) as nvarchar(max)) as ProjectName
+from (
+select A.TFSEntityAttributes as ProjectAttributes, B.RepoAttributes from
+search.tbl_IndexingUnit A
+join 
+(
+select TFSEntityAttributes as RepoAttributes, ParentUnitId, PartitionId
+		FROM Search.tbl_IndexingUnit
+		where IndexingUnitType IN ('TFVC_Repository', 'Git_Repository')
+		AND EntityType = 'Code'
+	    AND ((IndexingUnitType = 'Git_Repository'
+			AND CAST(Properties AS xml).exist('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+			declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+					  (/NS:IndexingProperties/NS:BranchIndexInfo/AS:KeyValueOfstringGitBranchIndexInfoRWfTSrgf/AS:Value/NS:LastIndexedCommitId[text() = "0000000000000000000000000000000000000000"])') = 1)
+		   OR (IndexingUnitType = 'TFVC_Repository'
+			   AND CAST(Properties AS xml).exist('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+			declare namespace AS="http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+					  (/NS:IndexingProperties/NS:LastIndexedChangeSetId[text() = "-1"])') = 1) )) B
+on A.PartitionId = B.PartitionId
+and A.IndexingUnitId = B.ParentUnitId
+) C

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CountCodeIndexingCompleted.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CountCodeIndexingCompleted.sql
@@ -1,0 +1,14 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of repositories for which the Fresh Indexing has already completed.
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+Select Count(Distinct(JobId)) as IndexingCompletedCount from tbl_JobHistory
+where 
+JobSource = @CollectionId
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and (ResultMessage like '%BeginBulkIndex-AccountFaultIn%Completed pipeline execution for IndexingUnit%EntityType: Code%'
+or ResultMessage like '%BeginBulkIndex-ReindexCollection%Completed pipeline execution for IndexingUnit%EntityType: Code%')

--- a/ADO_Server_Diagnostics_2025/SqlScripts/CountWorkItemIndexingCompleted.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/CountWorkItemIndexingCompleted.sql
@@ -1,0 +1,14 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of repositories for which the Fresh Indexing has already completed.
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+Select Count(Distinct(JobId)) as IndexingCompletedCount from tbl_JobHistory
+where 
+JobSource = @CollectionId
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and (ResultMessage like '%BeginBulkIndex-AccountFaultIn%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'
+or ResultMessage like '%BeginBulkIndex-ReindexCollection%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%')

--- a/ADO_Server_Diagnostics_2025/SqlScripts/EnableSearchOnOriginalContent.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/EnableSearchOnOriginalContent.sql
@@ -1,0 +1,10 @@
+/*
+Enable indexing and search on Original content for Code entity
+*/
+
+exec prc_SetRegistryValue 1, '#\Service\ALMSearch\Settings\EnableCodeSearchOnOriginalContent\', true
+
+exec prc_SetRegistryValue 1, '#\FeatureAvailability\Entries\Search.Server.IndexOriginalCodeContent\AvailabilityState\', 1
+
+-- Enable workitem tags sorting on the basis of system language
+exec prc_SetRegistryValue 1, '#\FeatureAvailability\Entries\WebAccess.Search.WorkItem.EnableTagsSorting\AvailabilityState\', 1

--- a/ADO_Server_Diagnostics_2025/SqlScripts/FixIndexingIndexName.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/FixIndexingIndexName.sql
@@ -1,0 +1,35 @@
+/**
+	This script fixes the index name in all repo indexing units (if the same is not available).
+	Database: Partition database
+	Parameter: Collection Id 
+**/
+DECLARE @CollectionId UNIQUEIDENTIFIER = $(CollectionId)
+
+-- Get the partition Id associated with collection
+DECLARE @PartitionId INT
+SELECT @PartitionId = [PartitionId]
+FROM [tbl_DatabasePartitionMap]
+WHERE ServiceHostId = @CollectionId
+
+-- Get the index name associated with collection
+DECLARE @IndexingIndexName NVARCHAR(MAX)
+SELECT @IndexingIndexName = CAST(
+	props.query(
+		'declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+		 declare namespace NS2="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+		/NS1:IndexingProperties/NS1:IndexIndices/NS2:IndexInfo/NS2:IndexName/text()') AS NVARCHAR(MAX)
+	)
+FROM 
+    (
+        SELECT CAST(Properties AS xml) AS props
+        FROM Search.tbl_IndexingUnit
+        WHERE IndexingUnitType = 'Collection' AND EntityType = 'Code'
+		      AND PartitionId = @PartitionId
+    ) a 
+
+-- Update all repo indexing properties with index name retrieved from collection
+DECLARE @IndexingIndexNameInfo NVARCHAR(MAX) = CONCAT('<a:IndexName>', @IndexingIndexName, '</a:IndexName>')
+UPDATE Search.tbl_IndexingUnit
+SET Properties = REPLACE(Properties, '<a:IndexName i:nil="true"/>', @IndexingIndexNameInfo)
+WHERE (IndexingUnitType = 'Git_Repository' OR IndexingUnitType = 'TFVC_Repository')  AND EntityType = 'Code'
+      AND PartitionId = @PartitionId


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 8 of 20).

Files:
- SqlScripts/CodeIndexingInProgressRepositories.sql
- SqlScripts/CountCodeIndexingCompleted.sql
- SqlScripts/CountWorkItemIndexingCompleted.sql
- SqlScripts/EnableSearchOnOriginalContent.sql
- SqlScripts/FixIndexingIndexName.sql
