### PR TITLE
Add ADO Server 2025 scripts (part 11 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/SqlScripts/ResumeCodeIndexing.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/ResumeCodeIndexing.sql
@@ -1,0 +1,8 @@
+--This script will enable code indexing for Search.
+
+DECLARE @features dbo.typ_KeyValuePairStringTableNullable
+
+INSERT INTO @features values('#\FeatureAvailability\Entries\Search.Server.Code.Indexing\AvailabilityState\', '1')
+EXEC prc_UpdateRegistry @partitionId=1, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features
+INSERT INTO @features values('#\FeatureAvailability\Entries\Search.Server.Code.CrudOperations\AvailabilityState\', '1')
+EXEC prc_UpdateRegistry @partitionId=1, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features

--- a/ADO_Server_Diagnostics_2025/SqlScripts/ResumeWikiIndexing.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/ResumeWikiIndexing.sql
@@ -1,0 +1,8 @@
+--This script will enable wiki indexing for Search.
+
+DECLARE @features dbo.typ_KeyValuePairStringTableNullable
+
+INSERT INTO @features values('#\FeatureAvailability\Entries\Search.Server.Wiki.Indexing\AvailabilityState\', '1')
+EXEC prc_UpdateRegistry @partitionId=1, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features
+INSERT INTO @features values('#\FeatureAvailability\Entries\Search.Server.Wiki.ContinuousIndexing\AvailabilityState\', '1')
+EXEC prc_UpdateRegistry @partitionId=1, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features

--- a/ADO_Server_Diagnostics_2025/SqlScripts/ResumeWorkItemIndexing.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/ResumeWorkItemIndexing.sql
@@ -1,0 +1,8 @@
+--This script will enable work item indexing for Search.
+
+DECLARE @features dbo.typ_KeyValuePairStringTableNullable
+
+INSERT INTO @features values('#\FeatureAvailability\Entries\Search.Server.WorkItem.Indexing\AvailabilityState\', '1')
+EXEC prc_UpdateRegistry @partitionId=1, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features
+INSERT INTO @features values('#\FeatureAvailability\Entries\Search.Server.WorkItem.CrudOperations\AvailabilityState\', '1')
+EXEC prc_UpdateRegistry @partitionId=1, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features

--- a/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/AddFoldersInExclusionList.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/AddFoldersInExclusionList.sql
@@ -1,0 +1,41 @@
+/** 
+    This sql script adds Tfvc folders to exclusion list. It fetches the existing ones, if any, and merges both.
+    Any files present inside these folders won't get indexed.
+**/
+
+DECLARE @CollectionId UNIQUEIDENTIFIER = $(CollectionId)
+DECLARE @FolderPaths NVARCHAR(MAX) = $(FolderPaths)
+DECLARE @ErrorMessage NVARCHAR(MAX)
+
+IF (@FolderPaths is NULL)
+    BEGIN
+	    RAISERROR('FolderPaths cannot be null', 16, -1, 'AddFoldersInExclusionList', 0);
+	    RETURN
+    END
+
+DECLARE @PartitionID INT
+SELECT @PartitionID = PartitionId FROM [dbo].[tbl_DatabasePartitionMap] WHERE ServiceHostId = @CollectionId
+IF(@PartitionID <= 0 OR @PartitionID is NULL)
+    BEGIN
+	    SELECT @ErrorMessage = FORMATMESSAGE('Invalid value of PartitionId: %d for Collection ID ''%s''.', @PartitionID, CONVERT(NVARCHAR(50), @CollectionId))
+	    RAISERROR(@ErrorMessage, 16, -1, 'AddFoldersInExclusionList', 0);
+	    RETURN
+    END
+
+
+DECLARE @ExistingPaths NVARCHAR(MAX)
+SELECT  @ExistingPaths = RegValue FROM [dbo].[tbl_RegistryItems] WHERE ParentPath = '#\Service\ALMSearch\Settings\' AND ChildItem = 'TfvcFolderPathsExcludedFromIndexing\' AND PartitionId = @PartitionID
+
+DECLARE @NewFolderPaths NVARCHAR(MAX)
+IF(@ExistingPaths is NULL)
+	BEGIN
+	SET @NewFolderPaths = @FolderPaths
+	END
+ELSE
+	BEGIN
+	SET @NewFolderPaths = @ExistingPaths + ',' + @FolderPaths
+	END
+	
+DECLARE @features [dbo].[typ_KeyValuePairStringTableNullable]
+INSERT INTO @features values('#\Service\ALMSearch\Settings\TfvcFolderPathsExcludedFromIndexing\', @NewFolderPaths)
+EXEC prc_UpdateRegistry @partitionId = @PartitionID, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features

--- a/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/DeleteAllFoldersInExclusionList.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/DeleteAllFoldersInExclusionList.sql
@@ -1,0 +1,19 @@
+/** 
+    This sql script deletes all folders present in exclusion list.
+**/
+
+DECLARE @CollectionId UNIQUEIDENTIFIER = $(CollectionId)
+DECLARE @ErrorMessage NVARCHAR(MAX)
+
+DECLARE @PartitionID INT
+SELECT @PartitionID = PartitionId FROM [dbo].[tbl_DatabasePartitionMap] WHERE ServiceHostId = @CollectionId
+IF(@PartitionID <= 0 OR @PartitionID is NULL)
+    BEGIN
+	    SELECT @ErrorMessage = FORMATMESSAGE('Invalid value of PartitionId: %d for Collection ID ''%s''.', @PartitionID, CONVERT(NVARCHAR(50), @CollectionId))
+	    RAISERROR(@ErrorMessage, 16, -1, 'AddFoldersInExclusionList', 0);
+	    RETURN
+    END
+
+DECLARE @features [dbo].[typ_KeyValuePairStringTableNullable]
+INSERT INTO @features values('#\Service\ALMSearch\Settings\TfvcFolderPathsExcludedFromIndexing\', NULL)
+EXEC prc_UpdateRegistry @partitionId = @PartitionID, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 11 of 20).

Files:
- SqlScripts/ResumeCodeIndexing.sql
- SqlScripts/ResumeWikiIndexing.sql
- SqlScripts/ResumeWorkItemIndexing.sql
- SqlScripts/TfvcExcludedFolders/AddFoldersInExclusionList.sql
- SqlScripts/TfvcExcludedFolders/DeleteAllFoldersInExclusionList.sql
