### PR TITLE
Add ADO Server 2025 scripts (part 12 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/FetchFoldersInExclusionList.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/FetchFoldersInExclusionList.sql
@@ -1,0 +1,17 @@
+/** 
+    This sql script fetches all folders present in exclusion list. Any files present inside these folders won't get indexed.
+**/
+
+DECLARE @CollectionId UNIQUEIDENTIFIER = $(CollectionId)
+DECLARE @ErrorMessage NVARCHAR(MAX)
+
+DECLARE @PartitionID INT
+SELECT @PartitionID = PartitionId FROM [dbo].[tbl_DatabasePartitionMap] WHERE ServiceHostId = @CollectionId
+IF(@PartitionID <= 0 OR @PartitionID is NULL)
+    BEGIN
+	    SELECT @ErrorMessage = FORMATMESSAGE('Invalid value of PartitionId: %d for Collection ID ''%s''.', @PartitionID, CONVERT(NVARCHAR(50), @CollectionId))
+	    RAISERROR(@ErrorMessage, 16, -1, 'AddFoldersInExclusionList', 0);
+	    RETURN
+    END
+
+SELECT RegValue as ExcludedFolders FROM [dbo].[tbl_RegistryItems] WHERE ParentPath = '#\Service\ALMSearch\Settings\' AND ChildItem = 'TfvcFolderPathsExcludedFromIndexing\' AND PartitionId = @PartitionID

--- a/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/RemoveFoldersFromExclusionList.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/TfvcExcludedFolders/RemoveFoldersFromExclusionList.sql
@@ -1,0 +1,49 @@
+/** 
+    This sql script removes folders from Tfvc indexing exclusion list. It fetches the existing ones, finds if any of the proveded one exists, and deletes them.
+    Any folders provided but not present already in exclusion list are ignored.
+**/
+
+DECLARE @CollectionId UNIQUEIDENTIFIER = $(CollectionId)
+DECLARE @FolderPathsToRemove NVARCHAR(MAX) = $(FolderPaths)
+DECLARE @ErrorMessage NVARCHAR(MAX)
+
+IF (@FolderPathsToRemove is NULL)
+    BEGIN
+	    RAISERROR('FolderPaths cannot be null', 16, -1, 'RemoveFoldersFromExclusionList', 0);
+	    RETURN
+    END
+
+DECLARE @PartitionID INT
+SELECT @PartitionID = PartitionId FROM [dbo].[tbl_DatabasePartitionMap] WHERE ServiceHostId = @CollectionId
+IF(@PartitionID <= 0 OR @PartitionID is NULL)
+    BEGIN
+	    SELECT @ErrorMessage = FORMATMESSAGE('Invalid value of PartitionId: %d for Collection ID ''%s''.', @PartitionID, CONVERT(NVARCHAR(50), @CollectionId))
+	    RAISERROR(@ErrorMessage, 16, -1, 'AddFoldersInExclusionList', 0);
+	    RETURN
+    END
+
+
+DECLARE @ExistingPaths NVARCHAR(MAX)
+SELECT  @ExistingPaths = RegValue FROM [dbo].[tbl_RegistryItems] WHERE ParentPath = '#\Service\ALMSearch\Settings\' AND ChildItem = 'TfvcFolderPathsExcludedFromIndexing\' AND PartitionId = @PartitionID
+
+DECLARE @DeleteFoldersTable TABLE (
+    FolderPath    nvarchar(max) NOT NULL
+)
+DECLARE @ExistingFoldersTable TABLE (
+    FolderPath    nvarchar(max) NOT NULL
+)
+
+INSERT into @DeleteFoldersTable SELECT value FROM string_split(@FolderPathsToRemove, ',')
+INSERT into @ExistingFoldersTable SELECT value FROM string_split(@ExistingPaths, ',')
+
+DELETE @ExistingFoldersTable FROM @ExistingFoldersTable A
+INNER JOIN @DeleteFoldersTable B on A.FolderPath = B.FolderPath
+
+
+DECLARE @NewFolderPaths NVARCHAR(MAX) = ''
+SELECT @NewFolderPaths = @NewFolderPaths + FolderPath + ',' FROM @ExistingFoldersTable
+SET @NewFolderPaths = SUBSTRING(@NewFolderPaths, 0, LEN(@NewFolderPaths))
+	
+DECLARE @features [dbo].[typ_KeyValuePairStringTableNullable]
+INSERT INTO @features values('#\Service\ALMSearch\Settings\TfvcFolderPathsExcludedFromIndexing\', @NewFolderPaths)
+EXEC prc_UpdateRegistry @partitionId = @PartitionID, @identityName = '00000000-0000-0000-0000-000000000000', @registryUpdates = @features

--- a/ADO_Server_Diagnostics_2025/SqlScripts/WikiAccountFaultInResult.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WikiAccountFaultInResult.sql
@@ -1,0 +1,10 @@
+/*
+Gets the result of the WikiAccountFaultIn Job for the collection
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+SELECT Top 1 Result, ResultMessage 
+	FROM tbl_JobHistory WITH (NOLOCK)
+	WHERE JobId = '27B11FD5-1DA5-48B4-A732-761CE99F5A5F'
+	AND JobSource = @CollectionId
+	ORDER BY StartTime DESC

--- a/ADO_Server_Diagnostics_2025/SqlScripts/WikiFailedIndexingActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WikiFailedIndexingActivity.sql
@@ -1,0 +1,15 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of Indexing operations failed in the given date range.
+*/
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+SELECT Count(Id) AS FailedIndexingCount
+		FROM Search.tbl_IndexingUnitChangeEvent AS IUCE join
+		Search.tbl_IndexingUnit as IU ON IU.IndexingUnitId = IUCE.IndexingUnitId and IU.PartitionId = IUCE.PartitionId
+		where IUCE.ChangeType = 'BeginBulkIndex' AND IUCE.State = 'Failed'
+		AND IU.IndexingUnitType = 'Git_Repository'
+		AND IU.EntityType = 'Wiki'
+		AND IU.PartitionId = (Select PartitionId from dbo.tbl_DatabasePartitionMap where ServiceHostId = @CollectionId)
+        AND IUCE.CreatedTimeUTC > DATEADD(DAY, -@Days, GETUTCDATE())

--- a/ADO_Server_Diagnostics_2025/SqlScripts/WikiIndexingCompletedActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WikiIndexingCompletedActivity.sql
@@ -1,0 +1,14 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of repositories for which the Fresh Indexing(new repository) has already completed in the give date range.
+*/
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+select Count(DISTINCT(TfsEntityId)) as IndexingCompletedCount from Search.tbl_IndexingUnit as IU join
+	Search.tbl_IndexingUnitChangeEvent  as IUCE ON IU.IndexingUnitId = IUCE.IndexingUnitId and IU.PartitionId = IUCE.PartitionId
+    where IU.EntityType = 'Wiki'
+        and IU.IndexingUnitType = 'Git_Repository'
+        and IUCE.CreatedTimeUTC > DATEADD(DAY, -@Days, GETUTCDATE())
+        and IUCE.State = 'Succeeded'
+        and IU.PartitionId = (Select PartitionId from dbo.tbl_DatabasePartitionMap where ServiceHostId = @CollectionId)


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 12 of 20).

Files:
- SqlScripts/TfvcExcludedFolders/FetchFoldersInExclusionList.sql
- SqlScripts/TfvcExcludedFolders/RemoveFoldersFromExclusionList.sql
- SqlScripts/WikiAccountFaultInResult.sql
- SqlScripts/WikiFailedIndexingActivity.sql
- SqlScripts/WikiIndexingCompletedActivity.sql
