### PR TITLE
Add ADO Server 2025 scripts (part 13 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/SqlScripts/WikiIndexingInProgressActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WikiIndexingInProgressActivity.sql
@@ -1,0 +1,13 @@
+--**UPDATE** Please enter the Collection id
+/*
+This script gets the number of repositories for which the indexing of a wiki git repository is in Progress.
+*/
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+
+SELECT Count(DISTINCT(TfsEntityId)) AS IndexingInProgressCount
+		FROM Search.tbl_IndexingUnit AS IU join 
+		Search.tbl_IndexingUnitChangeEvent  as IUCE ON IU.IndexingUnitId = IUCE.IndexingUnitId and IU.PartitionId = IUCE.PartitionId
+		where IUCE.ChangeType = 'BeginBulkIndex' AND IUCE.State in ('InProgress', 'Pending', 'Queued', 'FailedAndRetry')
+		AND IU.IndexingUnitType = 'Git_Repository'
+		AND IU.EntityType = 'Wiki'
+		AND IU.PartitionId = (Select PartitionId from dbo.tbl_DatabasePartitionMap where ServiceHostId = @CollectionId)

--- a/ADO_Server_Diagnostics_2025/SqlScripts/WikiIndexingInProgressRepositories.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WikiIndexingInProgressRepositories.sql
@@ -1,0 +1,14 @@
+--**UPDATE** Please enter the Collection id
+/*
+Gets the list of repositories for which indexing is in progress.
+*/
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+
+SELECT DISTINCT(TfsEntityId), substring(IU.TfsEntityAttributes, CHARINDEX('<RepositoryName>', TFSEntityAttributes) + 16,
+ (CHARINDEX('</RepositoryName>', TFSEntityAttributes) - (CHARINDEX('<RepositoryName>', TFSEntityAttributes) + 16)))  as RepositoryIndexingInProgress
+		FROM Search.tbl_IndexingUnit AS IU join 
+		Search.tbl_IndexingUnitChangeEvent  as IUCE ON IU.IndexingUnitId = IUCE.IndexingUnitId and IU.PartitionId = IUCE.PartitionId
+		where IUCE.ChangeType = 'BeginBulkIndex' AND IUCE.State in ('InProgress', 'Pending', 'Queued', 'FailedAndRetry')
+		AND IU.IndexingUnitType = 'Git_Repository'
+		AND IU.EntityType = 'Wiki'
+		AND IU.PartitionId = (Select PartitionId from dbo.tbl_DatabasePartitionMap where ServiceHostId = @CollectionId)

--- a/ADO_Server_Diagnostics_2025/SqlScripts/WorkItemAccountFaultInResult.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WorkItemAccountFaultInResult.sql
@@ -1,0 +1,10 @@
+/*
+Gets the result of the AccountFaultIn Job for the collection
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+SELECT Top 1 Result, ResultMessage 
+	FROM tbl_JobHistory
+	WHERE JobId = '03CEE4B8-ECC1-4E57-95CE-FA430FE0DBFB'
+	AND JobSource = @CollectionId 
+	ORDER BY StartTime DESC

--- a/ADO_Server_Diagnostics_2025/SqlScripts/WorkItemBulkIndexingActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WorkItemBulkIndexingActivity.sql
@@ -1,0 +1,13 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of repositories for which the Fresh Indexing(new repository) has already completed.
+*/
+
+Declare @CollectionId uniqueidentifier = $(CollectionID);
+Declare @Days int = $(DaysAgo);
+
+Select Count(Distinct(JobId)) as BulkIndexingCompletedCount from tbl_JobHistory
+where 
+JobSource = @CollectionId
+and EndTime >  DATEADD(DAY, -@Days, GETUTCDATE())
+and ResultMessage like '%Completed pipeline execution for IndexingUnit%EntityType: WorkItem%'

--- a/ADO_Server_Diagnostics_2025/SqlScripts/WorkItemBulkIndexingInProgressActivity.sql
+++ b/ADO_Server_Diagnostics_2025/SqlScripts/WorkItemBulkIndexingInProgressActivity.sql
@@ -1,0 +1,14 @@
+--**UPDATE** Please enter the Collection id and Days
+/*
+This script gets the number of repositories for which the Fresh Indexing(new repository) is in Progress.
+*/
+SELECT Count(TfsEntityId) as BulkIndexingInProgressCount
+		FROM Search.tbl_IndexingUnit as IU join 
+		Search.tbl_IndexingUnitChangeEvent  as IUCE on IU.IndexingUnitId = IUCE.IndexingUnitId
+		where IUCE.ChangeData like '%WorkItemBulkIndexEventData%' and IUCE.State in ('InProgress', 'Pending', 'Queued')
+		and IU.IndexingUnitType in ('Project')
+		and IU.EntityType = 'WorkItem'
+		and IU.PartitionId > 0
+		and IUCE.PartitionId > 0
+
+


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 13 of 20).

Files:
- SqlScripts/WikiIndexingInProgressActivity.sql
- SqlScripts/WikiIndexingInProgressRepositories.sql
- SqlScripts/WorkItemAccountFaultInResult.sql
- SqlScripts/WorkItemBulkIndexingActivity.sql
- SqlScripts/WorkItemBulkIndexingInProgressActivity.sql
