### PR TITLE
Add ADO Server 2025 scripts (part 15 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/ActionRelations.Tests.ps1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/ActionRelations.Tests.ps1
@@ -1,0 +1,104 @@
+﻿Set-StrictMode -Version Latest
+
+. "$PSScriptRoot\ActionRelations.ps1"
+
+Describe "Action relations" {
+    $ActionRepository = @()
+    Get-ChildItem -Path "$PSScriptRoot\*.psm1" | Foreach-Object { $ActionRepository += $_.BaseName }
+
+    It "should have all actions represented in `$ActionSupersedesRelation" {
+        $relationKeys = $ActionSupersedesRelation.Keys | % ToString
+        Compare-Object $ActionRepository $relationKeys | Should Be $null
+    }
+
+    It "should have all actions represented in `$ActionPrecedesRelation" {
+        $relationKeys = $ActionPrecedesRelation.Keys | % ToString
+        Compare-Object $ActionRepository $relationKeys | Should Be $null
+    }
+
+    It "should have valid and distinct action list in values of `$ActionSupersedesRelation" {
+        foreach ($actions in $ActionSupersedesRelation.Values)
+        {
+            $uniqueActionCount = @($actions | select -Unique).Count
+            $actualActionCount = $actions.Count
+            $actualActionCount | Should Be $uniqueActionCount
+
+            foreach ($action in $actions)
+            {
+                $ActionRepository.Contains($action) | Should Be $true
+            }
+        }
+    }
+
+    It "should have valid and distinct action list in values of `$ActionPrecedesRelation" {
+        foreach ($actions in $ActionPrecedesRelation.Values)
+        {
+            $uniqueActionCount = @($actions | select -Unique).Count
+            $actualActionCount = $actions.Count
+            $actualActionCount | Should Be $uniqueActionCount
+
+            foreach ($action in $actions)
+            {
+                $ActionRepository.Contains($action) | Should Be $true
+            }
+        }
+    }
+
+    It "should not have cyclic relations in `$ActionSupersedesRelation" {
+        Test-CycleInGraph -Graph $ActionSupersedesRelation | Should Be $false
+    }
+
+    It "should not have cyclic relations in `$ActionPrecedesRelation" {
+        Test-CycleInGraph -Graph $ActionPrecedesRelation | Should Be $false
+    }
+
+    It "should not have order relation between two actions if one supersedes the other" {
+        foreach ($relation in $ActionSupersedesRelation.GetEnumerator())
+        {
+            $keyAction = $relation.Name
+            foreach ($relationAction in $relation.Value)
+            {
+                $ActionPrecedesRelation[$keyAction].Contains($relationAction) | Should Be $false
+                $ActionPrecedesRelation[$relationAction].Contains($keyAction) | Should Be $false
+            }
+        }
+    }
+}
+
+Describe "Optimize-Actions" {
+    foreach ($relation in $ActionSupersedesRelation.GetEnumerator())
+    {
+        $supersederAction = $relation.Name
+        foreach ($supersededAction in $relation.Value)
+        {
+            It "should not return superseded action [$supersededAction] if action [$supersederAction] is also recommended" {
+                $result = Optimize-Actions -Actions @($supersededAction, $supersederAction)
+                $result | Should Be @($supersederAction)
+            }
+        }
+    }
+
+    $sortedActionRepository = Get-TopologicalSort -Graph $ActionPrecedesRelation
+    foreach ($relation in $ActionPrecedesRelation.GetEnumerator())
+    {
+        $precedingAction = $relation.Name
+        foreach ($followingAction in $relation.Value)
+        {
+            It "should return action [$precedingAction] before action [$followingAction]" {
+                $sortedActionRepository.IndexOf($precedingAction) | Should BeLessThan $sortedActionRepository.IndexOf($followingAction)
+            }
+        }
+    }
+    
+    It "should remove duplicate actions" {
+        $testActions = @("Request-ConfigureSearch", "Request-ConfigureSearch")
+        $result = Optimize-Actions -Actions $testActions
+        $result | Should Be @("Request-ConfigureSearch")
+    }
+
+    It "should remove higher degree superseded actions" {
+        $testActions = @("Request-ReconfigureSearch", "Request-ConfigureSearch", "Request-InstallSearchExtension")
+        $result = Optimize-Actions -Actions $testActions
+        $result | Should Be @("Request-ReconfigureSearch")
+    }
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/ActionRelations.ps1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/ActionRelations.ps1
@@ -1,0 +1,168 @@
+﻿Set-StrictMode -Version Latest
+
+<#
+Repair-Search executes a suite of analyzers. Each analyzer tries to detect a known issue and recommends one or more
+actions. These actions on execution would try to fix the issue detected. In few cases, a single analyzer may return 
+multiple actions or more commonly, multiple analyzers may return multiple actions. Not all actions are mutually
+exclussive; some have overlaps. In such a case, executing an action, say Action1, may not be necessary because another 
+action, say Action2, if executed would do the job for both the actions or reset the state so that Action1 is not 
+even required anymore. In this case, we define Action2 to supersede Action1, that is, if both Action1 and Action2 
+are recommended, only Action2 would be executed instead of executing both Action1 and Action2. 
+
+The hashtable below represents this relation as a directed acyclic graph defined using an adjacency list data structure.
+Vertices of the graph are actions and a directed edge from V1 to V2 means V1 supersedes V2.
+
+When you want to add a new action to this hashtable, check which of the existing actions should it supersede 
+(prevent execution) and add them to its value array. Also check which of the existing actions will supersede
+the new action and add it to their list.
+
+NOTE: All actions must be defined as keys in this hashtable. This is asserted by a Pester test defined in
+ActionRelations.Tests.ps1.
+#>
+$ActionSupersedesRelation = @{
+    "Remove-OrphanIndexedDocuments" = @()
+    "Request-ConfigureSearch" = @("Request-InstallSearchExtension")
+    "Request-FixElasticsearchClusterState" = @()
+    "Request-InstallSearchExtension" = @()
+    "Request-ReconfigureSearch" = @("Request-ConfigureSearch", "Request-InstallSearchExtension")
+    "Reset-ExtensionInstallationRegKeys" = @()
+    "Restart-Indexing" = @("Reset-ExtensionInstallationRegKeys", "Enable-IndexingFeatureFlags", "Remove-OrphanIndexedDocuments")
+    "Enable-IndexingFeatureFlags" = @()
+    "Remove-Index" = @()
+    "Request-Upgrade" = @()
+}
+
+<#
+With supersedence sorted out, we may still end up with multiple actions to execute. Now we have to decide the
+order in which these actions must be executed. While some actions may not have an ordering requirement, some 
+other actions may.
+
+The hashtable below represents this relation as a directed acyclic graph defined using an adjacency list data structure.
+Vertices of the graph are actions and a directed edge from V1 to V2 means V1 must be executed before V2.
+We use topological sort algorithm to get the desired ordering of actions recommended.
+
+When you want to add a new action to this hashtable, check which of the existing actions should it be executed
+before and add them to its value array. Also check which of the existing actions should precede the new action
+and add it to their list.
+
+NOTE: All actions must be defined as keys in this hashtable. This is asserted by a Pester test defined in
+ActionRelations.Tests.ps1.
+#>
+$ActionPrecedesRelation = @{
+    "Remove-OrphanIndexedDocuments" = @("Request-InstallSearchExtension")
+    "Request-ConfigureSearch" = @("Restart-Indexing")
+    "Request-FixElasticsearchClusterState" = @("Remove-OrphanIndexedDocuments", "Request-ConfigureSearch", "Request-InstallSearchExtension", "Request-ReconfigureSearch", "Restart-Indexing", "Enable-IndexingFeatureFlags")
+    "Request-InstallSearchExtension" = @("Restart-Indexing")
+    "Request-ReconfigureSearch" = @("Restart-Indexing")
+    "Reset-ExtensionInstallationRegKeys" = @()
+    "Restart-Indexing" = @()
+    "Enable-IndexingFeatureFlags" = @("Request-ConfigureSearch", "Request-InstallSearchExtension", "Request-ReconfigureSearch")
+    "Remove-Index" = @("Remove-OrphanIndexedDocuments", "Request-ConfigureSearch", "Request-FixElasticsearchClusterState", "Request-InstallSearchExtension", "Request-ReconfigureSearch", "Restart-Indexing", "Enable-IndexingFeatureFlags")
+    "Request-Upgrade" = @()
+}
+
+. "$PSScriptRoot\..\Utils\Algorithms.ps1"
+
+function Optimize-Actions
+{
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string[]] $Actions
+    )
+
+    Write-Verbose "Input actions = [$($Actions -join ', ')]."
+
+    # Remove duplicates
+    $optimizedActions = [System.Collections.Generic.List[string]]($Actions | select -Unique)
+
+    Write-Verbose "Deduplicated actions = [$($optimizedActions -join ', ')]."
+
+    $actionParamsMap = @{}
+    foreach ($action in $Actions)
+    {
+        $tokens = $action.Split(@(" "), [System.StringSplitOptions]::RemoveEmptyEntries)
+        if ($tokens.Count -eq 1)
+        {
+            $actionName = $tokens[0]
+            $actionParam = $null
+        }
+        elseif ($tokens.Count -eq 2)
+        {
+            $actionName = $tokens[0]
+            $actionParam = $tokens[1]
+        }
+        else
+        {
+            throw "Action [$action] has unsupported format. It can only be the name of the action cmdlet conditionally followed by a space followed by the value of `$AdditionalParam to pass along with the action."
+        }
+
+        if ($actionParamsMap.ContainsKey($actionName))
+        {
+            $actionParamsMap[$actionName] += @($actionParam)
+        }
+        else
+        {
+            $actionParamsMap[$actionName] = @($actionParam)
+        }
+    }
+
+    # Separate additional param from the action name for sanitization. It is assumed that all actions with the same name enjoy the same supersedence and precedence rules.
+    $optimizedActions = [System.Collections.Generic.List[string]]($actionParamsMap.Keys | select)
+
+    Write-Verbose "Actions post additional param separation = [$optimizedActions]."
+
+    # Remove actions superseded by optimized actions
+    $supersededActions = New-Object System.Collections.Generic.HashSet[string]
+    foreach ($action in $optimizedActions)
+    {
+        foreach ($supersededAction in $ActionSupersedesRelation[$action])
+        {
+            $supersededActions.Add($supersededAction) | Out-Null
+        }
+    }
+
+    Write-Verbose "Superseded actions = [$supersededActions]."
+
+    foreach ($supersededAction in $supersededActions)
+    {
+        $optimizedActions.Remove($supersededAction) | Out-Null
+    }
+
+    Write-Verbose "After removing superseded actions = [$optimizedActions]."
+
+    # Order actions
+    # Get topological sort for all actions in the repository
+    $topologicallySortedActionRepository = Get-TopologicalSort -Graph $ActionPrecedesRelation
+    Write-Verbose "Topologically sorted action repository = [$topologicallySortedActionRepository]."
+
+    # Given the ordering between all actions, select the recommended actions in the same order
+    $sortedActions = @()
+    foreach ($action in $topologicallySortedActionRepository)
+    {
+        if ($optimizedActions.Contains($action))
+        {
+            $sortedActions += $action
+        }
+    }
+
+    # Plugin additional params back with the action names
+    $sortedActionsWithParams = @()
+    foreach ($action in $sortedActions)
+    {
+        $additionalParams = $actionParamsMap[$action]
+        foreach ($param in $additionalParams)
+        {
+            if ($param)
+            {
+                $sortedActionsWithParams += "$action $param"
+            }
+            else
+            {
+                $sortedActionsWithParams += $action
+            }
+        }
+    }
+
+    return $sortedActionsWithParams
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Enable-IndexingFeatureFlags.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Enable-IndexingFeatureFlags.psm1
@@ -1,0 +1,76 @@
+Set-StrictMode -Version Latest
+
+function Enable-IndexingFeatureFlags
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "High")]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+        
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    $message = "Enable indexing of [$EntityType] in collection [$CollectionName]"
+    if ($PSCmdlet.ShouldProcess($message.ToUpperInvariant(), "Are you sure you want to $($message)?".ToUpperInvariant(), "Confirm"))
+    {
+        Write-Log "Enabling [$EntityType] indexing feature flags for collection [$CollectionName]..."
+        switch ($EntityType)
+        {
+            "Code"
+            {
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Code.Indexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.Indexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Code.CrudOperations" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Code.CrudOperations" -State On
+                break
+            }
+
+            "WorkItem"
+            {
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.WorkItem.Indexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.Indexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.WorkItem.CrudOperations" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.WorkItem.CrudOperations" -State On
+                break
+            }
+
+            "Wiki"
+            {
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Wiki.Indexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.Indexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State On
+                Set-FeatureFlag -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -FeatureName "Search.Server.Wiki.ContinuousIndexing" -State On
+                break
+            }
+
+            default
+            {
+                throw [System.NotImplementedException] "Support for entity type [$_] is not implemented."
+            }
+        }
+        
+        # Waiting for a few seconds for the feature flag changes to get processed
+        Start-Sleep -Seconds 5
+    }
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Remove-Index.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Remove-Index.psm1
@@ -1,0 +1,64 @@
+Set-StrictMode -Version Latest
+
+function Remove-Index
+{
+    <#
+    .SYNOPSIS
+    Deletes an index from Elasticsearch. Name of the index is passed as value of parameter $AdditionalParam.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "High")]
+    Param
+    (
+        [Parameter(Mandatory=$False)]
+        [string] $SQLServerInstance,
+
+        [Parameter(Mandatory=$True)]
+        [uri] $ElasticsearchServiceUrl,
+
+        [Parameter(Mandatory=$True)]
+        [PSCredential] $ElasticsearchServiceCredential,
+
+        [Parameter(Mandatory=$False)]
+        [string] $ConfigurationDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+
+        [Parameter(Mandatory=$True)]
+        [string] $AdditionalParam
+    )
+
+    $indexToRemove = $AdditionalParam
+    $response = Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Head -Command $indexToRemove -Verbose:$VerbosePreference
+    if ($response.StatusCode -eq 200)
+    {
+        $message = "Delete index [$AdditionalParam] in Elasticsearch"
+        if ($PSCmdlet.ShouldProcess($message.ToUpperInvariant(), "Are you sure you want to $($message)?".ToUpperInvariant(), "Confirm"))
+        {
+            $response = Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Delete -Command $indexToRemove -Verbose:$VerbosePreference
+            if ($response.StatusCode -eq 200)
+            {
+                Write-Log "Deleted index [$indexToRemove]."
+            }
+            else
+            {
+                Write-Log "Deletion of Elasticsearch index failed with error: [$($response | ConvertTo-Json)]."
+            }
+        }
+    }
+    elseif ($response.StatusCode -eq 404)
+    {
+        Write-Log "Index [$indexToRemove] does not exist."
+    }
+    else
+    {
+        Write-Log "Index Exists API failed with error: [$($response | ConvertTo-Json)]."
+    }
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
@@ -1,0 +1,92 @@
+Set-StrictMode -Version Latest
+
+function Remove-OrphanIndexedDocuments
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "High")]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+
+        [Parameter(Mandatory=$True)]
+        [uri] $ElasticsearchServiceUrl,
+
+        [Parameter(Mandatory=$True)]
+        [PSCredential] $ElasticsearchServiceCredential,
+
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    # Get collection Id, index name and mapping name from collection indexing unit
+    $sqlQueryProperties = "EntityType='$EntityType'"
+    $sqlFullPath = "$PSScriptRoot\..\SqlScripts\GetCollectionIndexingUnitDetails.sql"
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties
+    if ($queryResults)
+    {
+        Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose
+        $collectionId = [guid]($queryResults | Select-Object -ExpandProperty TfsEntityId)
+        $indexName = $queryResults | Select-Object -ExpandProperty IndexingIndexName
+        $documentContractType = $queryResults | Select-Object -ExpandProperty IndexContractType 
+        $mappingName = Get-MappingName -DocumentContractType $documentContractType
+        Write-Log "Collection Id: [$collectionId], Index name: [$indexName], Mapping name: [$mappingName]" -Level Verbose
+
+        $body = @"
+        {
+            "query": {
+                "bool": {
+                    "must": {
+                        "term": { "collectionId": "$collectionId" }
+                    },
+                    "must_not": {
+                        "bool": {
+                            "must": [
+                                { "term": { "_index": "$indexName" } },
+                                { "term": { "_type": "$mappingName" } }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+"@
+
+        # Get the number of documents to be deleted first
+        $url = "$($EntityType.ToLowerInvariant())*/_count"
+        $response = Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Post -Command $url -Body $body -Verbose:$VerbosePreference
+        if ($response.StatusCode -eq 200)
+        {
+            $impactedDocumentCount = ($response.Content | ConvertFrom-Json).count
+            if ($impactedDocumentCount -gt 0)
+            {
+                $message = "Clean-up [$impactedDocumentCount] [$EntityType] documents of collection [$CollectionName] indexed in unexpected indices/mappings"
+                if ($PSCmdlet.ShouldProcess($message.ToUpperInvariant(), "Are you sure you want to $($message)? This can take a long time if the number of documents to delete is large.".ToUpperInvariant(), "Confirm"))
+                {
+                    Remove-IndexedDocumentsInBatches -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -IndexPattern "$($EntityType.ToLowerInvariant())*" -Body $body
+                    Write-Log "Completed deletion of all orphan indexed documents from Elasticsearch."
+                }
+            }
+        }
+        else
+        {
+            Write-Log "Delete request failed with response: [$($response | ConvertTo-Json)]." -Level Error
+        }
+    }
+    else
+    {
+        throw "$EntityType collection indexing unit does not exist. This should have been caught earlier and this analyzer not invoked."
+    }
+}


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 15 of 20).

Files:
- Troubleshooting/Actions/ActionRelations.ps1
- Troubleshooting/Actions/ActionRelations.Tests.ps1
- Troubleshooting/Actions/Enable-IndexingFeatureFlags.psm1
- Troubleshooting/Actions/Remove-Index.psm1
- Troubleshooting/Actions/Remove-OrphanIndexedDocuments.psm1
