### PR TITLE
Add ADO Server 2025 scripts (part 16 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-ConfigureSearch.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-ConfigureSearch.psm1
@@ -1,0 +1,35 @@
+Set-StrictMode -Version Latest
+
+function Request-ConfigureSearch
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    Param
+    (
+        [Parameter(Mandatory=$False)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+        
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    Write-Log "[MANUAL ACTION REQUIRED] Search is not configured. Please configure Search feature using Azure DevOps Server Administration Console." -Level Attention
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-FixElasticsearchClusterState.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-FixElasticsearchClusterState.psm1
@@ -1,0 +1,48 @@
+Set-StrictMode -Version Latest
+
+function Request-FixElasticsearchClusterState
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    Param
+    (
+        [Parameter(Mandatory=$False)]
+        [string] $SQLServerInstance,
+
+        [Parameter(Mandatory=$True)]
+        [uri] $ElasticsearchServiceUrl,
+
+        [Parameter(Mandatory=$True)]
+        [PSCredential] $ElasticsearchServiceCredential,
+
+        [Parameter(Mandatory=$False)]
+        [string] $ConfigurationDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    $response = Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Get -Command "_cluster/allocation/explain" -Verbose:$VerbosePreference
+    if ($response.StatusCode -eq 200)
+    {
+        $clusterAllocationExplanation = $response.Content | ConvertFrom-Json | ConvertTo-Json -Depth 20 # The double convert is for formatting the JSON
+        Write-Log "[MANUAL ACTION REQUIRED] Analyse the cluster allocation explanation response below and try to mitigate the problem. Sometimes this state can be temporary so execute Repair-Search again. If you are unable to fix the cluster state, please contact support.`r`n$clusterAllocationExplanation" -Level Attention
+    }
+    elseif ($response.StatusCode -eq 400) # It can happen that the cluster was recovering. We saw it in red/yellow state before but here it becomes green. Then this API returns this status code
+    {
+        Write-Log "[MANUAL ACTION REQUIRED] It seems like the Elasticsearch cluster just became healthy. You may want to run Repair-Search one more time just to be sure." -Level Attention
+    }
+    else
+    {
+        throw "Cluster allocation explain API returned with an unexpected status code [$($response.StatusCode)]. Error: [$($response.ErrorMessage)]."
+    }
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-InstallSearchExtension.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-InstallSearchExtension.psm1
@@ -1,0 +1,35 @@
+Set-StrictMode -Version Latest
+
+function Request-InstallSearchExtension
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    Param
+    (
+        [Parameter(Mandatory=$False)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+        
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    Write-Log "[MANUAL ACTION REQUIRED] $EntityType search extension is not installed. Please install it before proceeding further." -Level Attention
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-ReconfigureSearch.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-ReconfigureSearch.psm1
@@ -1,0 +1,35 @@
+Set-StrictMode -Version Latest
+
+function Request-ReconfigureSearch
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    Param
+    (
+        [Parameter(Mandatory=$False)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+        
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    Write-Log "[MANUAL ACTION REQUIRED] Search is in an unsupported state. Please unconfigure and then configure Search feature using Azure DevOps Server Administration Console." -Level Attention
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-Upgrade.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Request-Upgrade.psm1
@@ -1,0 +1,84 @@
+Set-StrictMode -Version Latest
+
+function Request-Upgrade
+{
+    <#
+    .SYNOPSIS
+    Prompts a message to the user to upgrade Azure DevOps Server to a newer version where issues detected are fixed.
+    Product name to upgrade to is passed as value of parameter $AdditionalParam.
+    #>
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    Param
+    (
+        [Parameter(Mandatory=$False)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$False)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+        
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Tfs2018", "Tfs2018U1", "Tfs2018U2", "Tfs2018U3", "ADOServer2019")]
+        [string] $AdditionalParam
+    )
+
+    switch ($AdditionalParam)
+    {
+        "Tfs2018" 
+        { 
+            $productName = "Team Foundation Server 2018"
+            $productUrl = "https://docs.microsoft.com/en-us/visualstudio/releasenotes/tfs2018-relnotes"
+            break
+        }
+
+        "Tfs2018U1" 
+        { 
+            $productName = "Team Foundation Server 2018 Update 1"
+            $productUrl = "https://docs.microsoft.com/visualstudio/releasenotes/tfs2018-update1"
+            break
+        }
+
+        "Tfs2018U2" 
+        { 
+            $productName = "Team Foundation Server 2018 Update 2"
+            $productUrl = "https://docs.microsoft.com/visualstudio/releasenotes/tfs2018-update2"
+            break
+        }
+
+        "Tfs2018U3"
+        { 
+            $productName = "Team Foundation Server 2018 Update 3"
+            $productUrl = "https://docs.microsoft.com/visualstudio/releasenotes/tfs2018-update3"
+            break
+        }
+
+        "ADOServer2019"
+        { 
+            $productName = "Azure DevOps Server 2019"
+            $productUrl = "https://docs.microsoft.com/azure/devops/server/release-notes/azuredevops2019"
+            break
+        }
+
+        default
+        {
+            throw "Product [$AdditionalParam] is not a recommended/supported version to upgrade to. This is a code bug."
+        }
+    }
+
+    Write-Log "[MANUAL ACTION REQUIRED] Certain issues were identified which can be best fixed by upgrading. Please upgrade to $productName ($productUrl) or above. If you cannot and the issue still persists, please contact support." -Level Attention
+}


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 16 of 20).

Files:
- Troubleshooting/Actions/Request-ConfigureSearch.psm1
- Troubleshooting/Actions/Request-FixElasticsearchClusterState.psm1
- Troubleshooting/Actions/Request-InstallSearchExtension.psm1
- Troubleshooting/Actions/Request-ReconfigureSearch.psm1
- Troubleshooting/Actions/Request-Upgrade.psm1
