### PR TITLE
Add ADO Server 2025 scripts (part 17 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Reset-ExtensionInstallationRegKeys.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Reset-ExtensionInstallationRegKeys.psm1
@@ -1,0 +1,37 @@
+Set-StrictMode -Version Latest
+
+function Reset-ExtensionInstallationRegKeys
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$False)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+        
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    $regKey = "\Service\ALMSearch\Settings\IsExtensionOperationInProgress\$EntityType\Uninstalled"
+    Set-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -RegistryPath $regKey -Value $null
+    Write-Log "Removed registry [$regKey] from [$CollectionDatabaseName] database."
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Restart-Indexing.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Actions/Restart-Indexing.psm1
@@ -1,0 +1,153 @@
+Set-StrictMode -Version Latest
+
+function Restart-Indexing
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "High")]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$True)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$True)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType,
+
+        [Parameter(Mandatory=$False)]
+        [string] $AdditionalParam
+    )
+
+    # Reset uninstall in progress related registry keys
+    Reset-ExtensionInstallationRegKeys `
+        -SQLServerInstance $SQLServerInstance `
+        -CollectionDatabaseName $CollectionDatabaseName `
+        -CollectionName $CollectionName `
+        -EntityType $EntityType `
+        -AdditionalParam $AdditionalParam `
+        -Confirm:$false # Don't need explicit confirmation again as executing Restart-Indexing was already confirmed by the user
+
+    if (Test-BulkIndexingIsInProgress `
+        -SQLServerInstance $SQLServerInstance `
+        -ConfigurationDatabaseName $ConfigurationDatabaseName `
+        -CollectionDatabaseName $CollectionDatabaseName `
+        -CollectionName $CollectionName `
+        -EntityType $EntityType)
+    {
+        Write-Log "$EntityType bulk indexing of collection [$CollectionName] is already in progress. Skipping re-indexing." -Level Warn
+        return
+    }
+
+    $message = "Re-index [$EntityType] documents of collection [$CollectionName]"
+    if (!$PSCmdlet.ShouldProcess($message.ToUpperInvariant(), "Are you sure you want to $($message)? Re-indexing may take a long time to complete for a large collection.".ToUpperInvariant(), "Confirm"))
+    {
+        return
+    }
+
+    # Disable indexing
+    Disable-IndexingFeatureFlags `
+        -SQLServerInstance $SQLServerInstance `
+        -ConfigurationDatabaseName $ConfigurationDatabaseName `
+        -CollectionDatabaseName $CollectionDatabaseName `
+        -CollectionName $CollectionName `
+        -EntityType $EntityType
+
+    # Reset data from SQL
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $sqlParams = "CollectionId='$collectionId'", "EntityTypeString='$EntityType'", "EntityTypeInt=$(Get-EntityTypeId $EntityType)"
+    $sqlFilePath = "$PSScriptRoot\..\SqlScripts\CleanUpCollectionIndexingState.sql"
+    $response = Invoke-Sqlcmd -InputFile $sqlFilePath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlParams
+    Write-Log "Cleaned up all SQL tables storing indexing state."
+
+    # Delete data indexed in Elasticsearch
+    $allIndexRecords = (Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Get -Command "_cat/indices?v&h=index&format=json" -Verbose:$VerbosePreference).Content | ConvertFrom-Json
+    if ($allIndexRecords.Count -eq 0)
+    {
+        Write-Log "There are no indices in Elasticsearch and hence nothing to delete."
+    }
+    else
+    {
+        foreach ($indexRecord in $allIndexRecords)
+        {
+            Write-Log $indexRecord -Level Verbose
+            $indexName = $indexRecord.index
+            if ($indexName.StartsWith($EntityType.ToLowerInvariant()))
+            {
+                Write-Log "Deleting [$EntityType] documents of collection [$CollectionName] from index [$indexName]..."
+                Remove-IndexedDocumentsInBatches -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -IndexPattern $indexName -Body "{ `"query`": { `"term`": { `"collectionId`": `"$collectionId`" } } }"
+            }
+        }
+    }
+
+    # Get all Job Ids corresponding to all indexing units of the given entity type
+    $indexingJobIds = Invoke-Sqlcmd -Query "SELECT AssociatedJobId FROM Search.tbl_IndexingUnit WHERE EntityType = '$EntityType' AND AssociatedJobId IS NOT NULL AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty AssociatedJobId
+    if ($indexingJobIds)
+    {
+        $timeoutInMinutes = 15
+        Write-Log "Waiting for indexing activity to die down upto $timeoutInMinutes minutes..."
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($stopwatch.Elapsed.TotalMinutes -lt $timeoutInMinutes) # Waiting for a maximum of $timeoutInMinutes minutes
+        {
+            $indexingJobQueuedCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) As IndexingJobQueuedCount FROM dbo.tbl_JobQueue WHERE JobSource = '$collectionId' AND JobId IN ($(($indexingJobIds | ForEach-Object { "'$_'" }) -join ', '))" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty IndexingJobQueuedCount)
+            if ($indexingJobQueuedCount -eq 0)
+            {
+                Write-Log "All $EntityType indexing jobs have completed."
+                break
+            }
+            else
+            {
+                Write-Log "[$indexingJobQueuedCount] $EntityType indexing jobs are still queued/in-progress. Waiting for them to complete..." -Level Warn
+            }
+
+            Start-Sleep -Seconds 5
+        }
+    }
+    else
+    {
+        Write-Log "There are no $EntityType indexing jobs in progress."
+    }
+
+    # Enable indexing
+    Enable-IndexingFeatureFlags `
+        -SQLServerInstance $SQLServerInstance `
+        -ConfigurationDatabaseName $ConfigurationDatabaseName `
+        -CollectionDatabaseName $CollectionDatabaseName `
+        -CollectionName $CollectionName `
+        -EntityType $EntityType `
+        -WhatIf:$False `
+        -Confirm:$False `
+        -Verbose:$VerbosePreference
+
+    # Queue fault-in job if not queued already
+    if (!(Test-BulkIndexingIsInProgress `
+        -SQLServerInstance $SQLServerInstance `
+        -ConfigurationDatabaseName $ConfigurationDatabaseName `
+        -CollectionDatabaseName $CollectionDatabaseName `
+        -CollectionName $CollectionName `
+        -EntityType $EntityType))
+    {
+        Invoke-FaultInJob `
+            -SQLServerInstance $SQLServerInstance `
+            -ConfigurationDatabaseName $ConfigurationDatabaseName `
+            -CollectionDatabaseName $CollectionDatabaseName `
+            -CollectionName $CollectionName `
+            -EntityType $EntityType
+    }
+    else
+    {
+        Write-Log "[$EntityType] bulk indexing of collection [$CollectionName] is already in progress. Not queuing the job again." -Level Warn
+    }
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/AnalyzerRelations.Tests.ps1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/AnalyzerRelations.Tests.ps1
@@ -1,0 +1,76 @@
+﻿Set-StrictMode -Version Latest
+
+. "$PSScriptRoot\AnalyzerRelations.ps1"
+
+Describe "Analyzer relations" {
+    $AnalyzerRepository = @()
+    Get-ChildItem -Path "$PSScriptRoot\*.psm1" | Foreach-Object { $AnalyzerRepository += $_.BaseName }
+
+    It "should have all analyzers represented in `$AnalyzerPrecedesAndSupersedesRelation" {
+        $relationKeys = $AnalyzerPrecedesAndSupersedesRelation.Keys | % ToString
+        Compare-Object $AnalyzerRepository $relationKeys | Should Be $null
+    }
+
+    It "should have valid and distinct analyzer list in values of `$AnalyzerPrecedesAndSupersedesRelation" {
+        foreach ($analyzers in $AnalyzerPrecedesAndSupersedesRelation.Values)
+        {
+            $uniqueAnalyzerCount = @($analyzers | select -Unique).Count
+            $actualAnalyzerCount = $analyzers.Count
+            $actualAnalyzerCount | Should Be $uniqueAnalyzerCount
+
+            foreach ($analyzer in $analyzers)
+            {
+                $AnalyzerRepository.Contains($analyzer) | Should Be $true
+            }
+        }
+    }
+
+    It "should not have cyclic relations in `$AnalyzerPrecedesAndSupersedesRelation" {
+        Test-CycleInGraph -Graph $AnalyzerPrecedesAndSupersedesRelation | Should Be $false
+    }
+}
+
+Describe "Optimize-Analyzers" {
+    $sortedAnalyzerRepository = Get-TopologicalSort -Graph $AnalyzerPrecedesAndSupersedesRelation
+    foreach ($relation in $AnalyzerPrecedesAndSupersedesRelation.GetEnumerator())
+    {
+        $precedingAnalyzer = $relation.Name
+        foreach ($followingAnalyzer in $relation.Value)
+        {
+            It "should return analyzer [$precedingAnalyzer] before analyzer [$followingAnalyzer]" {
+                $sortedAnalyzerRepository.IndexOf($precedingAnalyzer) | Should BeLessThan $sortedAnalyzerRepository.IndexOf($followingAnalyzer)
+            }
+        }
+    }
+    
+    $optmizedAnalyzers = Optimize-Analyzers -Analyzers $sortedAnalyzerRepository
+    It "should return analyzer Test-ElasticsearchHealth before Test-FaultInJobInInfiniteRetries" {
+        $optmizedAnalyzers.IndexOf("Test-ElasticsearchHealth") | Should BeLessThan $optmizedAnalyzers.IndexOf("Test-FaultInJobInInfiniteRetries")
+    }
+
+    It "should remove duplicate analyzers" {
+        $testAnalyzers = @("Test-SqlHealth", "Test-SqlHealth")
+        $result = Optimize-Analyzers -Analyzers $testAnalyzers
+        $result | Should Be @("Test-SqlHealth")
+    }
+}
+
+Describe "Get-SupersededAnalyzers" {
+    It "should not return itself as superseded analyzer" {
+        foreach ($analyzer in $AnalyzerPrecedesAndSupersedesRelation.Keys)
+        {
+            $result = @(Get-SupersededAnalyzers -Analyzer $analyzer)
+            $result.Contains($analyzer) | Should Be $false
+        }
+    }
+
+    It "should not return anything for an analyzer which has no superseded analyzers" {
+        $result = @(Get-SupersededAnalyzers -Analyzer "Test-GeneralTfvcIssues")
+        $result.Count | Should Be 0
+    }
+
+    It "should return superseded analyzers even if there is no direct relation between them" {
+        $result = @(Get-SupersededAnalyzers -Analyzer "Test-SqlHealth")
+        $result.Contains("Test-IndicesHaveUnsupportedMappings") | Should Be $true
+    }
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/AnalyzerRelations.ps1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/AnalyzerRelations.ps1
@@ -1,0 +1,99 @@
+﻿Set-StrictMode -Version Latest
+
+<#
+Repair-Search executes a suite of analyzers. It makes sense that some analyzers be executed before other analyzers. For example,
+Test-*Health analyzers should be executed before known issue analyzers because the later may fail if the system is unhealthy.
+This is the precedence relation. Also, if an analyzer AN1 recommends one or more actions, executing another analyzer AN2 may 
+not be required. This is the supersedence relation. For analyzers (unlike actions), both these relations are the same.
+
+The hashtable below represents this relation as a directed acyclic graph defined using an adjacency list data structure.
+Vertices of the graph are analyzers and a directed edge from V1 to V2 means V1 should be executed before V2 and if V1
+recommends one more more actions, V2 should not be executed. Note that if edges V1->V2 and V2->V3 are present and
+V1 recommends an action, both V2 and V3 will not be executed. Hence, do not add relations to this hashtable if there is none,
+because that may result in not executing an analyzer. The ordering of analyzers is determined by topologically sorting this tree.
+
+When you want to add a new analyzer to this hashtable, check which of the existing analyzers should it be executed
+before and add them to its value array. Also check which of the existing analyzers should precede the new analyzer
+and add it to their list.
+
+NOTE: All analyzers must be defined as keys in this hashtable. This is asserted by a Pester test defined in
+AnalyzerRelations.Tests.ps1.
+#>
+$AnalyzerPrecedesAndSupersedesRelation = 
+@{ 
+    "Test-SqlHealth" = @("Test-ElasticsearchHealth", "Test-IndexingUnitPointsToDeletedIndex", "Test-FaultInJobInInfiniteRetries", "Test-GeneralTfvcIssues")
+    "Test-ElasticsearchHealth" = @("Test-IndicesHaveUnsupportedMappings", "Test-IndexingUnitPointsToDeletedIndex", "Test-FaultInJobInInfiniteRetries")
+    "Test-IndicesHaveUnsupportedMappings" = @()
+    "Test-IndexingUnitPointsToDeletedIndex" = @()
+    "Test-FaultInJobInInfiniteRetries" = @()
+    "Test-GeneralTfvcIssues" = @()
+}
+
+ "$PSScriptRoot\..\Utils\Algorithms.ps1"
+
+function Optimize-Analyzers
+{
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string[]] $Analyzers
+    )
+
+    Write-Verbose "Input analyzers = [$($Analyzers -join ', ')]."
+
+    # Remove duplicates
+    $optimizedAnalyzers = [System.Collections.Generic.List[string]]($Analyzers | select -Unique)
+
+    Write-Verbose "Deduplicated analyzers = [$($optimizedAnalyzers -join ', ')]."
+
+    # Order analyzers
+    # Get topological sort for all analyzers in the repository
+    $topologicallySortedAnalyzerRepository = Get-TopologicalSort -Graph $AnalyzerPrecedesAndSupersedesRelation
+    Write-Verbose "Topologically sorted analyzer repository = [$topologicallySortedAnalyzerRepository]."
+
+    # Given the ordering between all analyzers, select the recommended analyzers in the same order
+    $sortedAnalyzers = @()
+    foreach ($analyzer in $topologicallySortedAnalyzerRepository)
+    {
+        if ($optimizedAnalyzers.Contains($analyzer))
+        {
+            $sortedAnalyzers += $analyzer
+        }
+    }
+
+    return $sortedAnalyzers
+}
+
+function Get-SupersededAnalyzers
+{
+    <#
+    .SYNOPSIS
+    Given an analyzer, get all analyzers preceded and superseded by it. 
+    In terms of graph theory, this returns all vertices reachable from the given vertex through edge traversal.
+    #>
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $Analyzer
+    )
+
+    $result = New-Object System.Collections.Generic.Stack[string]
+    $visited = New-Object System.Collections.Generic.HashSet[string]
+    Invoke-DfsWalk -Graph $AnalyzerPrecedesAndSupersedesRelation -Vertex $Analyzer -Visited $visited -Result $result
+    
+    # Remove the top analyzer in the result stack because it is the input analyzer itself.
+    $top = $result.Pop()
+    if ($top -ne $Analyzer)
+    {
+        throw "Expected top of stack to be [$Analyzer] but found [$top]."
+    }
+
+    # Rest of the analyzers in the result stack are present in the DFS path from the input analyzer and by definition, depend on the input analyzer
+    $supersededAnalyzers = @()
+    while ($result.Count -gt 0)
+    {
+        $supersededAnalyzers += $result.Pop()
+    }
+    
+    return $supersededAnalyzers
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-ElasticsearchHealth.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-ElasticsearchHealth.psm1
@@ -1,0 +1,128 @@
+Set-StrictMode -Version Latest
+
+function Test-ElasticsearchHealth
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    [OutputType([string[]])]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$True)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$True)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType
+    )
+
+    # Verify connection parameters are correct
+    Confirm-ElasticsearchIsReachable -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Verbose:$VerbosePreference
+
+    # Verify cluster health is green
+    $clusterHealth = (Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Get -Command "_cluster/health" -Verbose:$VerbosePreference).Content | ConvertFrom-Json
+    Write-Log "Elasticsearch cluster health is [$clusterHealth]."
+    $clusterState = $clusterHealth.status
+    
+    if ($clusterState -ne "green")
+    {
+        Write-Log "Elasticsearch cluster state is [$clusterState]." -Level Error
+        return "Request-FixElasticsearchClusterState"
+    }
+    else
+    {
+        Write-Log "Elasticsearch cluster state is [$clusterState]."
+    }
+
+    # Verify number of documents for given collection and entity type is greater than zero
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    
+    $body = @"
+    {
+        "size": 0,
+        "query": {
+            "term": {
+                "collectionId": "$collectionId"
+            }
+        },
+        "aggs": {
+            "collections": {
+                "terms": {
+                    "field": "collectionId",
+                    "size": 1000
+                },
+                "aggs": {
+                    "indices": {
+                        "terms": {
+                            "field": "_index",
+                            "size": 1000
+                        },
+                        "aggs": {
+                            "mappings": {
+                                "terms": {
+                                    "field": "_type",
+                                    "size": 1000
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"@
+
+    $docCountResponse = (Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Post -Command "$($EntityType.ToLowerInvariant())*/_search?filter_path=aggregations.collections.buckets.key,aggregations.collections.buckets.indices.buckets.key,aggregations.collections.buckets.indices.buckets.mappings.buckets" -Body $body -Verbose:$VerbosePreference).Content | ConvertFrom-Json
+    Write-Log "Collection documents per index per mapping for entity type [$EntityType]`:`r`n$($docCountResponse | ConvertTo-Json -Depth 20)" -Level Verbose
+    if ([bool]$docCountResponse.PSobject.Properties.Item("aggregations"))
+    {
+        $indices = @($docCountResponse.aggregations.collections.buckets[0].indices.buckets)
+        if ($indices.Count -gt 1)
+        {
+            Write-Log "Documents for entity type [$EntityType] and collection [$CollectionName] are indexed in more than one indices." -Level Warn
+            return "Remove-OrphanIndexedDocuments"
+        }
+        else
+        {
+            $indexName = $indices[0].key
+            $mappings = @($indices[0].mappings.buckets)
+            if ($mappings.Count -gt 1)
+            {
+                Write-Log "Documents for entity type [$EntityType] and collection [$CollectionName] are indexed in more than one mapping of index [$indexName]." -Level Error
+                return "Remove-OrphanIndexedDocuments"
+            }
+            else
+            {
+                Write-Log "Number of documents indexed for entity type [$EntityType] and collection [$CollectionName] in index [$($indices[0].key)] and mapping [$($mappings[0].key)] = [$($mappings[0].doc_count)]."
+            }
+        }
+    }
+    else # Empty response
+    {
+        # If bulk indexing has just stated, it is possible to get zero results at first. We don't want to log a warning message in that case.
+        if (!(Test-BulkIndexingIsInProgress `
+            -SQLServerInstance $SQLServerInstance `
+            -ConfigurationDatabaseName $ConfigurationDatabaseName `
+            -CollectionDatabaseName $CollectionDatabaseName `
+            -CollectionName $CollectionName `
+            -EntityType $EntityType))
+        {
+            Write-Log "[MANUAL ACTION MAY BE REQUIRED] No document for entity type [$EntityType] and collection [$CollectionName] is indexed in Elasticsearch. If this is not expected, consider executing Restart-Indexing action." -Level Attention
+        }
+    }
+
+    return @() # No actions identified
+}


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 17 of 20).

Files:
- Troubleshooting/Actions/Reset-ExtensionInstallationRegKeys.psm1
- Troubleshooting/Actions/Restart-Indexing.psm1
- Troubleshooting/Analyzers/AnalyzerRelations.ps1
- Troubleshooting/Analyzers/AnalyzerRelations.Tests.ps1
- Troubleshooting/Analyzers/Test-ElasticsearchHealth.psm1
