### PR TITLE
Add ADO Server 2025 scripts (part 18 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-FaultInJobInInfiniteRetries.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-FaultInJobInInfiniteRetries.psm1
@@ -1,0 +1,51 @@
+Set-StrictMode -Version Latest
+
+function Test-FaultInJobInInfiniteRetries
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    [OutputType([string[]])]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType
+    )
+    
+    # Get the latest fault-in job result message
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+    $faultInJobId = Get-AccountFaultInJobId -EntityType $EntityType
+    $faultInJobResultMessage = Invoke-Sqlcmd -Query "SELECT TOP(1) ResultMessage FROM dbo.tbl_JobHistory WHERE JobSource = '$collectionId' AND JobId = '$faultInJobId' AND Result IN (0, 2) ORDER BY StartTime DESC" -ServerInstance $SQLServerInstance -Database $ConfigurationDatabaseName | Select-Object -ExpandProperty ResultMessage
+
+    # Check if it contains the message indicating it is waiting for extension uninstallation
+    if ($faultInJobResultMessage -and $faultInJobResultMessage.Contains("Requeue the Account Fault-In job since Extension Uninstall sequence is still in progress"))
+    {
+        # Check if the extension uninstallation in progress registry key is true
+        $regKey = "\Service\ALMSearch\Settings\IsExtensionOperationInProgress\$EntityType\Uninstalled"
+        $regValue = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -RegistryPath $regKey
+        if ($regValue -eq "True")
+        {
+            Write-Log "$EntityType indexing is blocked due to incorrect values of some registry keys." -Level Error
+            return "Reset-ExtensionInstallationRegKeys"
+        }
+    }
+
+    return @() # No actions identified
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
@@ -1,0 +1,60 @@
+Set-StrictMode -Version Latest
+
+function Test-GeneralTfvcIssues
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    [OutputType([string[]])]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType
+    )
+    
+    if ($EntityType -ne "Code")
+    {
+        Write-Log "This analyzer is only valid for Code entity type. It is not valid for [$EntityType] entity type."
+        return @()
+    }
+    
+    # Get all job Ids corresponding to TFVC repository indexing units
+    $tfvcRepoCount = [int](Invoke-Sqlcmd -Query "SELECT COUNT(1) AS TfvcRepoCount FROM Search.tbl_IndexingUnit WHERE EntityType = 'Code' AND IndexingUnitType = 'TFVC_Repository' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName | Select-Object -ExpandProperty TfvcRepoCount)
+    if ($tfvcRepoCount -eq 0)
+    {
+        Write-Log "This analyzer is only valid for TFVC repositories. No TFVC repository was found in collection [$CollectionName]."
+        return @()
+    }
+
+    $message = 
+@"
+There are a few known issues related to indexing TFVC files in the current version of Team Foundation Server.
+* tf destroy is not processed
+    DESCRIPTION: Search does not delete destroyed TFVC files from Elasticsearch.
+    IMPACT: Code search will return destroyed TFVC files in the result.
+    MITIGATION: Deleting the destroyed files from Elasticsearch will fix the problem. But if tf destroy is executed again, the problem will 
+        surface again. Till this bug is not fixed, please delete the TFVC files, wait for a day and only then destroy them. Once Search
+        processes the deletion, it is safe to destroy the file.
+"@
+
+    Write-Log $message -Level Warn
+
+    return @()
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
@@ -1,0 +1,73 @@
+Set-StrictMode -Version Latest
+
+function Test-IndexingUnitPointsToDeletedIndex
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    [OutputType([string[]])]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$True)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$True)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType
+    )
+
+    # Get indexing indices from all indexing units
+    $sqlQueryProperties = "EntityType='$EntityType'"
+    $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchIndexingIndices.sql"
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $sqlQueryProperties
+    if ($queryResults)
+    {
+        Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose
+        
+        $indexingIndexNames = @($queryResults | Select-Object -ExpandProperty IndexingIndexName | select -Unique | where { $_ }) # De-duplicating and removing empty values
+        if (!$indexingIndexNames)
+        {
+            Write-Log "No $EntityType indexing unit with indexing index name found. If re-indexing has just started, this is expected." -Level Warn
+            return @() # No actions identified
+        }
+
+        if ($indexingIndexNames.Count -gt 1)
+        {
+            Write-Log "Indexing units of collection [$CollectionName] have properties containing more than one indexing index [$indexingIndexNames]. Re-indexing is required to fix this state." -Level Error
+            return "Restart-Indexing"
+        }
+
+        $indexNameInSql = $indexingIndexNames[0]
+
+        # Check if the index exists in Elasticsearch. If not, recommend re-indexing
+        $response = Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Head -Command $indexNameInSql -Verbose:$VerbosePreference
+        if ($response.StatusCode -eq 404)
+        {
+            Write-Log "Indexing index name in SQL [$indexNameInSql] does not exist in Elasticsearch cluster at [$ElasticsearchServiceUrl]. Re-indexing is required." -Level Error
+            return "Restart-Indexing"
+        }
+        elseif ($response.StatusCode -ne 200)
+        {
+            Write-Log "Index Exists API failed with error: [$($response | ConvertTo-Json)]."
+        }
+    }
+    else
+    {
+        Write-Log "No $EntityType indexing unit with indexing index name found. If re-indexing has just started, this is expected." -Level Warn
+    }
+
+    return @() # No actions identified
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-IndicesHaveUnsupportedMappings.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-IndicesHaveUnsupportedMappings.psm1
@@ -1,0 +1,132 @@
+Set-StrictMode -Version Latest
+
+function Test-IndicesHaveUnsupportedMappings
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    [OutputType([string[]])]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+        
+        [Parameter(Mandatory=$True)]
+        [uri] $ElasticsearchServiceUrl,
+        
+        [Parameter(Mandatory=$True)]
+        [PSCredential] $ElasticsearchServiceCredential,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+       
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType
+    )
+
+    $actionsRecommended = @()
+
+    # This analyzer will not require an update in the future because in latest releases, there is only one mapping per index.
+    # As a result, we won't need to delete indices having unsupported mappings because then there would be no chance of mapping
+    # collision.
+    $unsupportedMappingNames = 
+    @{
+        "Code" = @("SourceNoDedupeFileContract", "SourceNoDedupeFileContractV2")
+    }
+    
+    if (!$unsupportedMappingNames.ContainsKey($EntityType))
+    {
+        Write-Log "This analyzer is not supported for entity type [$EntityType]."
+        return @()
+    }
+
+    # Make sure the unsupported mappings defined above are not actually supported. This is just to make sure the script has no bugs.
+    $supportedDocumentContractType = Get-SupportedDocumentContractType -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -EntityType $EntityType
+    $supportedMapping = Get-MappingName -DocumentContractType $supportedDocumentContractType
+    if ($unsupportedMappingNames[$EntityType].Contains($supportedMapping))
+    {
+        throw "List of unsupported mapping names and/or expected mapping name are incorrectly setup. They both have [$mappingName] in common. Fix the bug in the script."
+    }
+    
+    # Get all indices with unsupported mappings
+    foreach ($unsupportedMappingName in $unsupportedMappingNames[$EntityType])
+    {
+        $command = "_mapping/$unsupportedMappingName"
+        $response = Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Get -Command $command -Verbose:$VerbosePreference
+        
+        $indicesWithUnsupportedMapping = @()
+        if ($response.StatusCode -eq 200)
+        {
+            # Indices with unsupported mapping is present. Find them.
+            $indices = $($response.Content | ConvertFrom-Json).PSObject.Properties.Name
+            foreach ($index in $indices)
+            {
+                $indicesWithUnsupportedMapping += $index
+            }
+        }
+        elseif ($response.StatusCode -eq 404)
+        {
+            # This is the expected scenario - Unsupported mapping not found
+        }
+        else
+        {
+            throw "GET $command failed with status code [$($response.StatusCode)] unexpectedly."
+        }
+
+        if ($indicesWithUnsupportedMapping.Count -eq 0)
+        {
+            continue
+        }
+
+        foreach ($index in $indicesWithUnsupportedMapping)
+        {
+            Write-Log "Index [$index] has unsupported mapping [$unsupportedMappingName]. It must be deleted." -Level Error
+            $actionsRecommended += "Remove-Index $index"
+        }
+
+        # Get the list of collections indexed in these indices
+        $body = @"
+        {
+            "size": 0,
+            "aggs": {
+                "collections": {
+                    "terms": {
+                        "field": "collectionId",
+                        "size": 1000
+                    }
+                }
+            }
+        }
+"@
+
+        $command = "$($indicesWithUnsupportedMapping -join ',')/_search?filter_path=aggregations.collections.buckets"
+        $response = Invoke-ElasticsearchCommand -ElasticsearchServiceUrl $ElasticsearchServiceUrl -ElasticsearchServiceCredential $ElasticsearchServiceCredential -Method Post -Command $command -Body $body -Verbose:$VerbosePreference
+        if ($response.StatusCode -ne 200)
+        {
+            throw "Failed to execute Elasticsearch request with following error: [$($response.ErrorMessage)]"
+        }
+
+        $aggregationResponse = $response.Content | ConvertFrom-Json
+        foreach ($collection in $aggregationResponse.aggregations.collections.buckets)
+        {
+            $affectedCollectionId = $collection.key
+            $affectedCollectionName = Get-CollectionName -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionId $affectedCollectionId
+            if ($affectedCollectionName -eq $CollectionName)
+            {
+                Write-Log "Collection [$affectedCollectionName] has [$($collection.doc_count)] documents in the index to be deleted. It must be re-indexed." -Level Error
+                $actionsRecommended += "Restart-Indexing"
+            }
+            else
+            {
+                Write-Log "[MANUAL ACTION REQUIRED] Collection [$affectedCollectionName] has [$($collection.doc_count)] documents in the index to be deleted. $EntityType search and indexing might both be failing for this collection. Please execute Repair-Search for this collection separately." -Level Attention
+            }
+        }
+    }
+
+    return $actionsRecommended
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-SqlHealth.psm1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Analyzers/Test-SqlHealth.psm1
@@ -1,0 +1,184 @@
+Set-StrictMode -Version Latest
+
+function Test-SqlHealth
+{
+    [CmdletBinding(SupportsShouldProcess=$True, ConfirmImpact = "None")]
+    [OutputType([string[]])]
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [string] $SQLServerInstance,
+
+        [Parameter(Mandatory=$False)]
+        [uri] $ElasticsearchServiceUrl,
+
+        [Parameter(Mandatory=$False)]
+        [PSCredential] $ElasticsearchServiceCredential,
+
+        [Parameter(Mandatory=$True)]
+        [string] $ConfigurationDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionDatabaseName,
+
+        [Parameter(Mandatory=$True)]
+        [string] $CollectionName,
+
+        [Parameter(Mandatory=$True)]
+        [ValidateSet("Code", "WorkItem", "Wiki")]
+        [string] $EntityType
+    )
+
+    # Verify connection parameters are correct
+    Confirm-SqlIsReachable -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName
+
+    # Verify IsSearchConfigured setting in Configuration DB
+    Write-Log "Verifying IsSearchConfigured setting in Configuration DB..."
+
+    $configureRegKey = "\Service\ALMSearch\Settings\IsSearchConfigured"
+    $isSearchConfigured = Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $configureRegKey
+    if (!$isSearchConfigured -or $isSearchConfigured -eq "False")
+    {
+        Write-Log "Search is not configured." -Level Error
+        return "Request-ConfigureSearch"
+    }
+
+    # Verify SearchUrl setting in Configuration DB
+    Write-Log "Verifying Search URL settings in Configuration DB..."
+
+    $atRegKey = "\Service\ALMSearch\Settings\ATSearchPlatformConnectionString"
+    $atSearchPlatformConnectionString = [uri](Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $atRegKey)
+    if (!$atSearchPlatformConnectionString)
+    {
+        Write-Log "AT search platform connection string registry key [$atRegKey] not found." -Level Error
+        return "Request-ReconfigureSearch"
+    }
+    
+    if ($atSearchPlatformConnectionString -ne $ElasticsearchServiceUrl)
+    {
+        throw [ArgumentException]"Search URL configured [$atSearchPlatformConnectionString] is not equal to the input [$ElasticsearchServiceUrl]. If the URL provided to the script is incorrect, invoke this script again with the correct URL, else reconfigure Search feature with the correct URL."
+    }
+
+    $jaRegKey = "\Service\ALMSearch\Settings\JobAgentSearchPlatformConnectionString"
+    $jaSearchPlatformConnectionString = [uri](Get-ServiceRegistryValue -SQLServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -RegistryPath $jaRegKey)
+    if (!$jaSearchPlatformConnectionString)
+    {
+        Write-Log "JobAgent search platform connection string registry key [$jaRegKey] not found." -Level Error
+        return "Request-ReconfigureSearch"
+    }
+    
+    if ($jaSearchPlatformConnectionString -ne $ElasticsearchServiceUrl)
+    {
+        throw [ArgumentException]"Search URL configured [$jaSearchPlatformConnectionString] is not equal to the input [$ElasticsearchServiceUrl]. If the URL provided to the script is incorrect, invoke this script again with the correct URL, else reconfigure Search feature with the correct URL."
+    }
+
+    # Verify entity specific extension is installed
+    Write-Log "Verifying $EntityType search extension is installed..."
+
+    $isExtensionInstalled = Test-ExtensionInstalled -SQLServerInstance $SQLServerInstance -CollectionDatabaseName $CollectionDatabaseName -EntityType $EntityType
+    if (!$isExtensionInstalled)
+    {
+        return "Request-InstallSearchExtension"
+    }
+
+    # Verify primary indexing FFs in Configuration DB
+    Write-Log "Verifying primary indexing feature flags..."
+    $indexingFeatureFlagsEnabled = Test-IndexingFeatureFlagsAreEnabled -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionDatabaseName $CollectionDatabaseName -CollectionName $CollectionName -EntityType $EntityType
+    if (!$indexingFeatureFlagsEnabled)
+    {
+        return "Enable-IndexingFeatureFlags"
+    }
+
+    Write-Log "Verifying that collection IU is present. If not present, verifying bulk indexing is queued..."
+    if (!(Invoke-Sqlcmd -Query "SELECT IndexingUnitId FROM Search.tbl_IndexingUnit WHERE IndexingUnitType = 'Collection' AND EntityType = '$EntityType' AND IsDeleted = 0 AND PartitionId = 1" -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName))
+    {
+        if (Test-BulkIndexingIsInProgress `
+            -SQLServerInstance $SQLServerInstance `
+            -ConfigurationDatabaseName $ConfigurationDatabaseName `
+            -CollectionDatabaseName $CollectionDatabaseName `
+            -CollectionName $CollectionName `
+            -EntityType $EntityType)
+        {
+            Write-Log "$EntityType collection indexing unit does not exist and bulk-indexing is in progress. Skipping rest of the validations in this analyzer because they require the collection indexing unit to te present."
+            return @()
+        }
+    }
+
+    # Verify Collection IU properties' Index and Query URL match the configuration DB URL
+    # i.e. Connection string from properties <IndexESConnectionString>{URL}</IndexESConnectionString>
+    #                                        <QueryESConnectionString>{URL}</QueryESConnectionString>
+    Write-Log "Verifying Collection IU properties' Index and Query URL match the configuration DB connection URL..."
+
+    $collectionId = Get-CollectionId -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -CollectionName $CollectionName
+
+    $collectionPropUrlParams = "CollectionId='$collectionID'", "EntityType='$EntityType'"
+    $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchCollectionProperties.sql"
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams
+    if ($queryResults)
+    {
+        Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose
+        
+        $colIndexESConnectionString = [uri]($queryResults | Select-Object -ExpandProperty IndexESConnectionString)
+        $colQueryESConnectionString = [uri]($queryResults | Select-Object -ExpandProperty QueryESConnectionString)
+        if ($colIndexESConnectionString -ne $ElasticsearchServiceUrl)
+        {
+            Write-Log "Invalid Search URL in Collection IU properties' IndexESConnectionString [$colIndexESConnectionString] for entity type [$EntityType]." -Level Error
+            return "Restart-Indexing"
+        }
+        
+        if ($colQueryESConnectionString -ne $ElasticsearchServiceUrl)
+        {
+            Write-Log "Invalid Search URL in Collection IU properties' QueryESConnectionString [$colQueryESConnectionString] for entity type [$EntityType]." -Level Error
+            return "Restart-Indexing"
+        }
+    }
+    else
+    {
+        Write-Log "Collection indexing unit for entity type [$EntityType] and collection [$CollectionName] not found." -Level Error
+        return "Restart-Indexing"
+    }
+    
+    # Verify document contract type in registry is as expected
+    $supportedDocumentContractType = Get-SupportedDocumentContractType -SqlServerInstance $SQLServerInstance -ConfigurationDatabaseName $ConfigurationDatabaseName -EntityType $EntityType
+    $expectedDocumentContractType = Get-ExpectedDocumentContractType -EntityType $EntityType
+    if ($supportedDocumentContractType -ne $expectedDocumentContractType)
+    {
+        # We have never encountered this discrepancy hence we are throwing instead of fixing
+        throw "Expected document contract type for entity type $EntityType is [$expectedDocumentContractType] but found [$supportedDocumentContractType]."
+    }
+
+    # Verify Collection IU properties' ES ContractTypes for Indexing and Query
+    # i.e. <IndexContractType>{contractType}</IndexContractType>
+    #      <QueryContractType>{contractType}</QueryContractType>
+    Write-Log "Verifying Collection IU properties' ES ContractTypes for Indexing and Query..."
+
+    $collectionPropUrlParams = "CollectionId='$CollectionID'", "EntityType='$EntityType'"
+    $sqlFullPath = "$PSScriptRoot\..\SqlScripts\SearchCollectionProperties.sql"
+    $queryResults = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Variable $collectionPropUrlParams
+    if ($queryResults)
+    {
+        Write-Log "SQL query results: [$($queryResults | Out-String)]." -Level Verbose
+        
+        $colIndexContractType = $queryResults | Select-Object -ExpandProperty IndexContractType
+        $colQueryContractType = $queryResults | Select-Object -ExpandProperty QueryContractType
+        
+        if ($colIndexContractType -ne $supportedDocumentContractType)
+        {
+            Write-Log "Invalid ES contract type in Collection IU properties' IndexContractType [$colIndexContractType] for entity type [$EntityType]. This can result in indexing failures." -Level Error
+            return "Restart-Indexing"
+        }
+        
+        if ($colQueryContractType -ne $supportedDocumentContractType)
+        {
+            Write-Log "Invalid ES contract type in Collection IU properties' QueryContractType [$colQueryContractType] for entity type [$EntityType]. This can result in indexing failures." -Level Error
+            return "Restart-Indexing"
+        }
+    }
+    else
+    {
+        Write-Log "Collection indexing unit for entity type [$EntityType] and collection [$CollectionName] not found." -Level Error
+        return "Restart-Indexing"
+    }
+
+    return @() # No actions identified
+}


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 18 of 20).

Files:
- Troubleshooting/Analyzers/Test-FaultInJobInInfiniteRetries.psm1
- Troubleshooting/Analyzers/Test-GeneralTfvcIssues.psm1
- Troubleshooting/Analyzers/Test-IndexingUnitPointsToDeletedIndex.psm1
- Troubleshooting/Analyzers/Test-IndicesHaveUnsupportedMappings.psm1
- Troubleshooting/Analyzers/Test-SqlHealth.psm1
