### PR TITLE
Add ADO Server 2025 scripts (part 19 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Repair-Search.ps1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Repair-Search.ps1
@@ -1,0 +1,255 @@
+# Azure DevOps Server 2025 - Elasticsearch 8.14
+<#
+    .SYNOPSIS
+    For a given collection and entity type, detect and mitigate known issues in Azure DevOps Server 2025.
+
+    .DESCRIPTION
+    Repair-Search works with two main concepts - Analyzers and Actions.
+        
+    Analyzers are cmdlets defined inside .\Analyzers directory. They are executed by Repair-Search in a well-defined order.
+    These analyzers try to detect any known issues or incorrect configuration in the system. After all analyzers are executed, 
+    they return one or more recommended actions.
+    
+    Actions are cmdlets defined inside .\Actions directory. Actions fix the problem detected earlier by the analyzers.
+    By default, actions that have high impact on the system are not executed without user confirmation. So, it is safe to execute this script.
+    If you feel the recommended action should not be executed, you can choose to do so when prompted by this script.
+    If you want to just check what actions would be executed without actually executing them, pass -WhatIf switch with this script.
+    If you want to execute all recommended actions without user confirmation, set $ConfirmPreference to 'None'.
+
+    Execute Repair-Search. Execute the recommended actions (manual or automated). Repeat this till no more action is recommended.
+
+    .PARAMETER SQLServerInstance
+    The SQL server instance hosting the configuration and collection databases.
+    Examples: "ServerName", "ServerName\InstanceName", "localhost", ".", "ServerName,1433"
+
+    .PARAMETER ElasticsearchServiceUrl
+    URL of Elasticsearch service. Must include protocol (http/https) and port.
+    Examples: "http://localhost:9200", "https://elastic-server:9200"
+
+    .PARAMETER ElasticsearchServiceCredential
+    Credential for connecting to the Elasticsearch service. Use Get-Credential to create.
+    For local Elasticsearch without authentication, you can use empty credentials.
+
+    .PARAMETER ConfigurationDatabaseName
+    Configuration database name for Azure DevOps Server.
+    Default name is usually "AzureDevOps_Configuration" or "TFS_Configuration"
+
+    .PARAMETER CollectionDatabaseName
+    Collection database name for the impacted collection.
+    Example: "AzureDevOps_DefaultCollection", "AzureDevOps_MyCollection"
+
+    .PARAMETER CollectionName
+    Name of the impacted collection (as shown in Azure DevOps Server Administration Console).
+    Example: "DefaultCollection", "MyCollection"
+
+    .PARAMETER EntityType
+    Entity type to repair: Code (source code), WorkItem (work items), or Wiki (wiki pages).
+    Valid values: "Code", "WorkItem", "Wiki"
+
+    .INPUTS
+    None. You cannot pipe objects to Repair-Search.
+
+    .OUTPUTS
+    None. Repair-Search does not return any object.
+
+    .EXAMPLE
+    PS>.\Repair-Search -SQLServerInstance "." -ConfigurationDatabaseName "AzureDevOps_Configuration" -CollectionDatabaseName "AzureDevOps_DefaultCollection" -CollectionName "DefaultCollection" -ElasticsearchServiceUrl "http://localhost:9200" -ElasticsearchServiceCredential $(Get-Credential) -EntityType "Code"
+    
+    Repairs code search issues for the DefaultCollection.
+    - SQL Server is on the local machine (represented by ".")
+    - Standard database names for Azure DevOps Server 2025
+    - Elasticsearch is running locally on default port 9200
+    - Prompts for Elasticsearch credentials via dialog
+    - Repairs code search functionality
+    
+    .EXAMPLE
+    PS># Store credentials once to avoid repeated prompts
+    PS>$cred = Get-Credential -UserName "elastic" -Message "Enter Elasticsearch password"
+    PS>.\Repair-Search -SQLServerInstance "MYSERVER\SQLEXPRESS" -ConfigurationDatabaseName "AzureDevOps_Configuration" -CollectionDatabaseName "AzureDevOps_MyProject" -CollectionName "MyProject" -ElasticsearchServiceUrl "http://elastic-server:9200" -ElasticsearchServiceCredential $cred -EntityType "Code"
+    
+    Repairs code search for a custom collection on a named SQL Server instance.
+    - SQL Server instance name is "MYSERVER\SQLEXPRESS"
+    - Custom collection database "AzureDevOps_MyProject"
+    - Remote Elasticsearch server
+    - Pre-stored credentials to avoid prompts
+    
+    .EXAMPLE
+    PS>.\Repair-Search -SQLServerInstance "." -ConfigurationDatabaseName "AzureDevOps_Configuration" -CollectionDatabaseName "AzureDevOps_DefaultCollection" -CollectionName "DefaultCollection" -ElasticsearchServiceUrl "http://localhost:9200" -ElasticsearchServiceCredential $(Get-Credential) -EntityType "WorkItem" -WhatIf
+    
+    Simulates repair of work item search issues without making any changes.
+    Use -WhatIf to see what actions would be performed before actually running them.
+    
+    .EXAMPLE
+    PS># Run without confirmation prompts for automated scenarios
+    PS>$ConfirmPreference = 'None'
+    PS>$cred = New-Object PSCredential("elastic", (ConvertTo-SecureString "password" -AsPlainText -Force))
+    PS>.\Repair-Search -SQLServerInstance "." -ConfigurationDatabaseName "AzureDevOps_Configuration" -CollectionDatabaseName "AzureDevOps_DefaultCollection" -CollectionName "DefaultCollection" -ElasticsearchServiceUrl "http://localhost:9200" -ElasticsearchServiceCredential $cred -EntityType "Wiki"
+    
+    Repairs wiki search issues without user confirmation prompts.
+    Useful for automated scripts or when you're confident about the actions to be taken.
+#>
+[CmdletBinding(SupportsShouldProcess=$True)]
+Param
+(
+    [Parameter(Mandatory=$True)]
+    [string] $SQLServerInstance,
+
+    [Parameter(Mandatory=$True)]
+    [string] $ConfigurationDatabaseName,
+
+    [Parameter(Mandatory=$True)]
+    [string] $CollectionDatabaseName,
+
+    [Parameter(Mandatory=$True)]
+    [string] $CollectionName,
+
+    [Parameter(Mandatory=$True)]
+    [uri] $ElasticsearchServiceUrl,
+
+    [Parameter(Mandatory=$True)]
+    [PSCredential] $ElasticsearchServiceCredential,
+
+    [Parameter(Mandatory=$True)]
+    [ValidateSet("Code", "WorkItem", "Wiki")]
+    [string] $EntityType
+)
+
+$ErrorActionPreference = "Stop" # We do not want to continue executing the script if we encounter a failure
+
+$confirmationRequired = $ConfirmPreference -gt "None"
+
+Import-Module "$PSScriptRoot\Utils\Common.psm1" -DisableNameChecking -Force -Verbose:$false
+
+# Saving the value of log file path to a global variable so that it is not required to pass it along to every function invoked.
+$logFilePath = "$PSScriptRoot\Repair-Search_$(((Get-Date).ToUniversalTime()).ToString(`"yyyy-MM-ddTHH-mm-ssZ`")).log"
+Set-Variable LogFilePath -Option AllScope -Scope Global -Force -Value $logFilePath -Confirm:$false -WhatIf:$false
+
+# $VerbosePreference does not get passed to all cmdlets by default for some reason. To avoid having to pass it explicitly to all cmdlets
+# which is prone to manual error, we will save its value in a global variable which will be accessible everywhere.
+Set-Variable RepairSearchVerbosePreference -Option ReadOnly -Scope Global -Force -Value $VerbosePreference -Confirm:$false -WhatIf:$false
+
+try
+{
+    Write-Log "=== Start Repair-Search ===" -Verbose:$VerbosePreference
+
+    $analyzerRepository = @()
+    $actionRepository = @()
+
+    # Importing all analyzer modules
+    Get-ChildItem -Path "$PSScriptRoot\Analyzers\*.psm1" | Foreach-Object { Import-Module $_.FullName -Force -Verbose:$false; $analyzerRepository += $_.BaseName; }
+    . "$PSScriptRoot\Analyzers\AnalyzerRelations.ps1"
+
+    # Importing all action modules
+    Get-ChildItem -Path "$PSScriptRoot\Actions\*.psm1" | Foreach-Object { Import-Module $_.FullName -Force -Verbose:$false; $actionRepository += $_.BaseName; }
+    . "$PSScriptRoot\Actions\ActionRelations.ps1"
+
+    $totalActionsRecommended = @()
+
+    $analyzersRemainingToExecute = [System.Collections.Generic.List[string]](Optimize-Analyzers -Analyzers $analyzerRepository)
+    while ($analyzersRemainingToExecute.Count -gt 0)
+    {
+        $analyzer = $analyzersRemainingToExecute[0]
+
+        Write-Log "======================================================================================"
+        Write-Log "Executing analyzer [$analyzer]..."
+        $actionsRecommended = @(& $analyzer `
+            -SQLServerInstance $SQLServerInstance `
+            -ConfigurationDatabaseName $ConfigurationDatabaseName `
+            -CollectionDatabaseName $CollectionDatabaseName `
+            -CollectionName $CollectionName `
+            -ElasticsearchServiceUrl $ElasticsearchServiceUrl `
+            -ElasticsearchServiceCredential $ElasticsearchServiceCredential `
+            -EntityType $EntityType `
+            -Verbose:$VerbosePreference `
+            -WhatIf:$WhatIfPreference `
+            -Confirm:$confirmationRequired `
+            -ErrorAction Stop)
+
+        if ($actionsRecommended.Count -gt 0)
+        {
+            # Verify actions are supported
+            foreach ($actionRecommended in $actionsRecommended)
+            {
+                $actionName = $actionRecommended.Split(@(" "), [System.StringSplitOptions]::RemoveEmptyEntries)[0]
+                if (!$actionRepository.Contains($actionName))
+                {
+                    throw "Action [$actionName] is not supported. Only the following actions are supported: [$actionRepository]. This is a code bug."
+                }
+            }
+
+            Write-Log "Actions recommended are [$($actionsRecommended -join ', ')]." -Level Warn
+            $totalActionsRecommended += $actionsRecommended
+
+            # Remove superseded analyzers from the execution list
+            $supersededAnalyzers = Get-SupersededAnalyzers -Analyzer $analyzer
+            foreach ($supersededAnalyzer in $supersededAnalyzers)
+            {
+                $analyzersRemainingToExecute.Remove($supersededAnalyzer) | Out-Null
+                Write-Log "Will not execute analyzer [$supersededAnalyzer] because analyzer [$analyzer] has reported problems." -Level Verbose
+            }
+        }
+        else
+        {
+            Write-Log "No issues found!"
+        }
+
+        $analyzersRemainingToExecute.Remove($analyzer) | Out-Null # Removing the analyzer just executed
+    }
+
+    if ($totalActionsRecommended.Count -eq 0)
+    {
+        Write-Log "======================================================================================"
+        Write-Log "No known issues found. System seems to be healthy. If not, please collect diagnostic data by following steps in https://github.com/Microsoft/Code-Search/blob/master/Azure_DevOps_Server_2019/SearchDiagonistics/README.txt, and file an issue at https://developercommunity.visualstudio.com/content/problem/post.html?space=22." -Level Attention
+        Write-Log "======================================================================================"
+    }
+    else
+    {
+        $sanitizedActions = Optimize-Actions -Actions $totalActionsRecommended -ErrorAction Stop
+        Write-Log "======================================================================================"
+        Write-Log "Analysis is complete. Final list of recommended actions = [$($sanitizedActions -join ', ')]." -Level Warn
+
+        foreach ($action in $sanitizedActions)
+        {
+            $tokens = $action.Split(@(" "), [System.StringSplitOptions]::RemoveEmptyEntries)
+            if ($tokens.Count -eq 1)
+            {
+                $actionCmdlet = $tokens[0]
+                $additionalParam = $null
+            }
+            elseif ($tokens.Count -eq 2)
+            {
+                $actionCmdlet = $tokens[0]
+                $additionalParam = $tokens[1]
+            }
+
+            Write-Log "======================================================================================"
+            Write-Log "Executing action [$action]..." -Level Warn
+            & $actionCmdlet `
+                -SQLServerInstance $SQLServerInstance `
+                -ConfigurationDatabaseName $ConfigurationDatabaseName `
+                -CollectionDatabaseName $CollectionDatabaseName `
+                -CollectionName $CollectionName `
+                -ElasticsearchServiceUrl $ElasticsearchServiceUrl `
+                -ElasticsearchServiceCredential $ElasticsearchServiceCredential `
+                -EntityType $EntityType `
+                -AdditionalParam $additionalParam `
+                -Verbose:$VerbosePreference `
+                -WhatIf:$WhatIfPreference `
+                -Confirm:$confirmationRequired `
+                -ErrorAction Stop
+        }
+    }
+}
+catch [ArgumentException]
+{
+    Write-Log "Inputs provided to Repair-Search may be incorrect. See the error message below for more details:`r`n$_" -Level Attention
+}
+catch
+{
+    $message = ("Message:`r`n" + ($_ | Out-String) + "`r`nStack Trace:`r`n" + ($_.ScriptStackTrace))
+    Write-Log "Repair-Search failed with following exception:`r`n$message" -Level Error
+}
+finally
+{
+    Write-Log "Log file saved at $LogFilePath" -Level Info
+}

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/CleanUpCollectionIndexingState.sql
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/CleanUpCollectionIndexingState.sql
@@ -1,0 +1,81 @@
+-- This script cleans up all the tables/entries which has the indexing state of given entity type and given collection in collection database.
+
+Declare @CollectionId UNIQUEIDENTIFIER = $(CollectionID);
+Declare @EntityTypeString VARCHAR(32) = $(EntityTypeString);
+Declare @EntityTypeInt TINYINT = $(EntityTypeInt);
+
+IF (OBJECT_ID(N'Search.tbl_ResourceLockTable') IS NOT NULL)
+BEGIN
+    DELETE FROM Search.tbl_ResourceLockTable
+        WHERE LeaseId IN (
+            SELECT DISTINCT(IUCE.LeaseId) FROM Search.tbl_IndexingUnitChangeEvent IUCE INNER JOIN Search.tbl_IndexingUnit IU
+                ON IUCE.IndexingUnitId = IU.IndexingUnitId AND IU.EntityType = @EntityTypeString AND IUCE.PartitionId = 1)
+            AND PartitionId = 1
+END
+
+-- Delete indexing unit change events corresponding to indexing units of the given entity type
+DELETE IUCE FROM Search.tbl_IndexingUnitChangeEvent IUCE INNER JOIN Search.tbl_IndexingUnit IU ON IUCE.IndexingUnitId = IU.IndexingUnitId AND IU.EntityType = @EntityTypeString AND IUCE.PartitionId = 1
+
+-- Delete orphan indexing unit change events
+DELETE IUCE FROM Search.tbl_IndexingUnitChangeEvent IUCE LEFT JOIN Search.tbl_IndexingUnit IU ON IUCE.IndexingUnitId = IU.IndexingUnitId WHERE IU.IndexingUnitId IS NULL AND IUCE.PartitionId = 1
+
+IF (OBJECT_ID(N'Search.tbl_ItemLevelFailures') IS NOT NULL)
+BEGIN
+    DELETE ILF FROM Search.tbl_ItemLevelFailures ILF INNER JOIN Search.tbl_IndexingUnit IU ON ILF.IndexingUnitId = IU.IndexingUnitId AND IU.EntityType = @EntityTypeString AND ILF.PartitionId = 1
+END
+
+IF (OBJECT_ID(N'Search.tbl_IndexingUnitIndexingInformation') IS NOT NULL)
+BEGIN
+    DELETE FROM Search.tbl_IndexingUnitIndexingInformation WHERE EntityType = @EntityTypeInt AND PartitionId = 1
+END
+
+IF (OBJECT_ID(N'Search.tbl_JobYield') IS NOT NULL)
+BEGIN
+    DELETE FROM Search.tbl_JobYield WHERE EntityType = @EntityTypeString AND PartitionId = 1
+END
+
+IF (OBJECT_ID(N'Search.tbl_TreeStore') IS NOT NULL)
+BEGIN
+    DELETE FROM Search.tbl_TreeStore WHERE EntityType = @EntityTypeString AND PartitionId = 1
+END
+
+IF (@EntityTypeString = 'Code')
+BEGIN
+    IF (OBJECT_ID(N'Search.tbl_CustomRepositoryInfo') IS NOT NULL)
+    BEGIN
+        DELETE FROM Search.tbl_CustomRepositoryInfo WHERE PartitionId = 1
+    END
+    
+    IF (OBJECT_ID(N'Search.tbl_DisabledFiles') IS NOT NULL)
+    BEGIN
+        DELETE FROM Search.tbl_DisabledFiles WHERE PartitionId = 1
+    END
+    
+    IF (OBJECT_ID(N'Search.tbl_FileMetadataStore') IS NOT NULL)
+    BEGIN
+        DELETE FROM Search.tbl_FileMetadataStore WHERE PartitionId = 1
+    END
+    
+    IF (OBJECT_ID(N'Search.tbl_TempFileMetadataStore') IS NOT NULL)
+    BEGIN
+        DELETE FROM Search.tbl_TempFileMetadataStore WHERE PartitionId = 1
+    END
+END
+
+IF (@EntityTypeString = 'Wiki')
+BEGIN
+    IF (OBJECT_ID(N'Search.tbl_IndexingUnitWikis') IS NOT NULL)
+    BEGIN
+        DELETE FROM Search.tbl_IndexingUnitWikis WHERE PartitionId = 1
+    END
+END
+
+IF (@EntityTypeString = 'WorkItem')
+BEGIN
+    IF (OBJECT_ID(N'Search.tbl_ClassificationNode') IS NOT NULL)
+    BEGIN
+        DELETE FROM Search.tbl_ClassificationNode WHERE PartitionId = 1
+    END
+END
+
+DELETE FROM Search.tbl_IndexingUnit WHERE EntityType = @EntityTypeString AND PartitionId = 1

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/GetCollectionIndexingUnitDetails.sql
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/GetCollectionIndexingUnitDetails.sql
@@ -1,0 +1,24 @@
+-- This script fetches some information from collection indexing unit for the given entity type
+
+DECLARE @EntityType VARCHAR(32) = $(EntityType)
+
+SELECT 
+    TfsEntityId,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:IndexIndices/NS1:IndexInfo/NS1:IndexName/text()') AS nvarchar(MAX)) AS IndexingIndexName,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    /NS:IndexingProperties/NS:IndexContractType/text()') AS nvarchar(MAX)) AS IndexContractType,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:IndexIndices/NS1:IndexInfo/NS1:Routing/text()') AS nvarchar(MAX)) AS IndexingIndexRouting,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:QueryIndices/NS1:IndexInfo/NS1:IndexName/text()') AS nvarchar(MAX)) AS QueryIndexName,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    /NS:IndexingProperties/NS:QueryContractType/text()') AS nvarchar(MAX)) AS QueryContractType,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:QueryIndices/NS1:IndexInfo/NS1:Routing/text()') AS nvarchar(MAX)) AS QueryIndexRouting
+FROM Search.tbl_IndexingUnit
+WHERE EntityType = @EntityType AND IndexingUnitType = 'Collection' AND IsDeleted = 0 AND PartitionId = 1

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/QueueJob.sql
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/QueueJob.sql
@@ -1,0 +1,10 @@
+DECLARE @HostId UNIQUEIDENTIFIER = $(HostId)
+DECLARE @JobId UNIQUEIDENTIFIER = $(JobId)
+
+DECLARE @jobList dbo.typ_JobQueueUpdateTable
+INSERT INTO @jobList VALUES (@JobId, 10)
+DECLARE @priorityLevel INT = 10
+DECLARE @delaySeconds INT = 0
+DECLARE @queueAsDormant BIT = 0
+
+EXEC dbo.prc_QueueJobs @HostId, @jobList, @priorityLevel, @delaySeconds, @queueAsDormant

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/readme.txt
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/readme.txt
@@ -1,0 +1,301 @@
+# Azure DevOps Server 2025 - Elasticsearch 8.14 Troubleshooting Scripts
+
+Note: These scripts need to run either from the DT machine or a machine with SQL Server 2012 or higher installed. 
+The scripts currently are checked in here : https://github.com/microsoft/Code-Search Just download the complete folder to run the scripts.
+
+List of scripts :
+
+	1. MissingIndexFolderTriggerCollectionIndexing
+	2. OptimizeElasticIndex
+	3. PauseIndexing
+	4. ResumeIndexing
+	5. RecentIndexingActivity
+	6. ReIndexFiles
+	7. ReIndexingCodeRepository
+	8. SetIndexingStateRepository
+	9. CleanUpShardDetails
+	10. ExludedTfvcFoldersForIndexing
+	11. ExtensionInstallIndexingStatus
+	12. FixIndexingIndexName
+	13. GetCollectionReIndexingActivityStatus
+	14. GetElasticsearchDocCountPerRepository
+	15. GetRepositoryReInexingActivityStatus
+	16. GetReIndexingStatusOfFiles
+	17. TriggerCollectionIndexing
+	18. WipeOutAndResetElasticSearch
+	19. CollectionDBSearchDiagnostics
+	20. ConfigurationDBSearchDiagnostics
+	21. ElastiSearchDiagnostics
+	22. RepairSearch
+	
+
+	1. MissingIndexFolderTriggerCollectionIndexing:
+
+	Use of Script: 
+	This script cleans up the collection indexing state. It uses "CleanUpCollectionIndexingState_IndexDelete.sql". 
+	It Queue's Code, Work Item & Wiki Indexing job for the collection.
+	This script is similar to the TriggerCollectionIndexing.ps1, the only difference being, this should be run on a specific scenario when the “Index folder was deleted manually”.
+	Required Parameters:
+	We need to provide certain parameters to run this script
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+	
+	2. OptimizeElasticIndex:
+	
+	Use of Script: 
+	The optimize index operation will expunge all deleted documents of a given index.
+	This operation could cause very large shards to remain on disk until all the documents present in the index are just deleted documents.
+	Required Parameters:
+		ElasticServerUrl(ex: http://localhost:9200)
+		IndexName(ex: Code* for all code indices)
+		
+	3. PauseIndexing:
+	
+	Use of Script: 
+	This would pause indexing for all the collections.
+	To run this script, We should have a machine running SQL Server 2012 or higher.
+	Required Parameters:
+		SQLServerInstance
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		EntityType(ex: Code, WorkItem, Wiki or ALL)
+		
+	4. ResumeIndexing:
+	
+	Use of Script:
+	This will Resume the indexing for all the collections.
+	To run this script, We should have a machine running SQL Server 2012 or higher.
+	Required Parameters:
+		SQLServerInstance
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		EntityType(ex: Code, WorkItem, Wiki or ALL)
+		
+	5. Re-IndexFiles:
+	
+	Use of Script:
+	This script configures the provided path of a repository in a collection for Re-Indexing.
+	It also queue's the maintenance job so that the above event is processed immediately or else it would wait for the next check-in/periodic job run to get processed.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		ProjectName(update the project name here in which re-indexing should take place)
+		RepositoryName(update the repository name)
+		Path(path of the file/folder that should be indexed ex:/DefaultCollection/Test/_wiki/wikis/Test.wiki/1/Microsoft-Azure)
+		
+	6. RecentIndexingActivity:
+	
+	Use of Script:
+	By running this script, we get the count of repositories for which indexing jobs(bulkIndexing/continuousIndexing) has completed and we can get the count of FailedIndexing jobs.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		Days(Enter the days since last indexing was triggered for this collection)
+		EntityType(Code,WorkItem,Wiki or All)
+		
+	7. Re-IndexingCodeRepository:
+	
+	Use of Script:
+	This script queue's re-indexing job for a selected repository.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		IndesxiUnitType(ex: Git_Repository/TFVC_Repository)
+		RepositoryName(Provide the Repository Name that you want to re-index)
+	
+	8. SetIndexingStateRepository:
+
+	Use of Script:
+	This script sets the indexing state of the given repository in a collection to On or Off.
+	It also queue's the maintenance job so that the above event is processed immediately or else it would wait for the next check-in/periodic job run to get processed.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		ProjectName(update the project name here in which re-indexing should take place)
+		RepositoryName(update the repository name)
+		IndexingState(Set the Indexing State On/Off)
+		
+	9. CleanUpShardDetails:
+
+	Use of Script:
+	This scripts cleans the shard details table from the configuration database
+	Required Parameters:
+		SQLServerInstance
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		
+	10. ExludedTfvcFoldersForIndexing:
+
+	Use of Script:
+	By using this script, we can add/remove desired folders to Indexing Exclusion list. Also we can delete all the folders in the list and fetch the list of folders present in exclusion list.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		OperationType(Add, Remove, Delete, Fetch)
+		
+	11. ExtensionInstallIndexingStatus:
+	
+	Use of Script:
+	This script validates if the collection has code/WorkItem/Wiki extension installed and Fetches the Code/WorkItem/Wiki Extension install indexing status.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		Days(Enter the days since last indexing was triggered for this collection)
+		EntityType(Code,WorkItem,Wiki or All)
+		
+	12. FixIndexingIndexName:
+
+	Use of Script:
+		This script is used to Fix the index name in all repo indexing units.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		
+	13. GetCollectionReIndexingActivityStatus:
+	
+	Use of Script:
+	By using this script, We can get the collection indexing status for a given collection like number of repositories completed bulk indexing and repositories in progress.
+	Required Parameters:
+		UserCollection(ex: DefaultCollection)
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		Source(Location of previous Elasticsearch aggregation output)
+		Uri(URI for Elasticsearch instance/ex: http://localhost:9200)
+		
+	14. GetElasticsearchDocCountPerRepository:
+	
+	Use of Script:
+	With this script, We can Fetch repository documents count data from provided ES instance. Output will be stored in a single json file at the given destination.
+	Required Parameters: 
+		Uri(URI for ElasticSearch instance. Ex: http://localhost:9200)
+		Destination(Destination where the output file will be saved.)
+		
+	15. GetRepositoryReInexingActivityStatus:
+
+	Use of Script:
+	Display repository indexing status for a given collection.
+	This script depends on the output of GetElasticSearchDocCountPerRepository.ps1
+	Required Parameters:
+		userCollection(ex: DefaultCollection)
+		userProject(Project name)
+		userRepository( Repository name)
+		Source(Location of previous Elasticsearch aggregation output)
+		Uri(URI for ElasticSearch instance. Ex: http://localhost:9200)
+		
+	16. GetReIndexingStatusOfFiles:
+	
+	Use of Script:
+	This script configures a path of a repository for re-indexing. This gives files/folders are yet to be indexed in repository.
+	Required Parameters:
+	    SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		ProjectName(update the project name here in which re-indexing should take place)
+		RepositoryName(update the repository name)
+		Path(File/Folder for which re-index status has to be checked. Ex: /DefaultCollection/Test/_wiki/wikis/Test.wiki/1/Microsoft-Azure)
+		
+	17. TriggerCollectionIndexing:
+
+	Use of Script:
+	This script uses "CleanUpCollectionIndexingState.sql" to clean- up the Code, WorkItem or Wiki Collection Indexing state and queue the Code, WorkItem or WikiIndexing job for the collection.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		EntityType(Code,WorkItem,Wiki or All)
+		
+	18. WipeOutAndResetElasticSearch:
+
+	Use of Script:
+	It will delete/cleans-up current indexed data for all the collections.
+	This script would wipe out the index of all the collections, which would mean search won't work on any of the collections.
+	Required Parameters:
+	N/A
+
+	19. CollectionDBSearchDiagnostics:
+
+	Use of Script:
+	Extracts the Search diagnostics data from the specified collection database and 
+	Fetches IndexingUnit data into IndexingUnit.csv
+	Fetches IndexingUnitChangeEvent data into IndexingUnitChangeEvent.csv
+	Fetches ItemLevelFailures data into ItemLevelFailures.csv
+	Fetches JobYield data into JobYield.csv
+	Fetches ResourceLock data into ResourceLock.csv
+	Fetches DisabledFiles data into DisabledFiles.csv
+	Fetches Search registry data for collection into SearchSettingRegistriesOfCollection.csv
+	Fetches ClassificationNode data into ClassificationNode.csv
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+	
+	20. ConfigurationDBSearchDiagnostics:
+	
+	Use of Script:
+	Extracts the Search diagnostics data from the specified configuration database and
+	Fetches Service Host data into ServiceHost.csv
+	Fetches Search URL config data into SearchConnectionUrlRegistries.csv
+	Fetches Job Throttling config data into JobThrottlingRegistries.csv
+	Fetches Search registry data into SearchSettingRegistries.csv
+	Fetches JobQueue data into JobQueue.csv
+	Fetches Job History data into JobHistory.csv
+	
+	Required Parameters:
+		SQLServerInstance
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		Days(number of days since when the tbl_JobHistory data needs to be fetched)
+
+	21. ElastiSearchDiagnostics:
+	
+	Use of Script:
+	This script is used to fetch all the diagnostics data(Basic connectivity test, _cluster/health, _cluster/allocation/explain, _cat/shards, _mapping, _cat/nodes, _settings, _cluster/settings, _aliases) of Elastic search by providing the elastic search url.
+	
+	Required Parameters:
+		ElasticsearchServerUrl(URL of Elasticsearch service. Example: http://es-server:9200)
+		
+	22. RepairSearch:
+	
+	Usage of Script:
+	.SYNOPSIS
+	    For a given collection and entity type, detect and mitigate known issues.
+	
+	    .DESCRIPTION
+	    Repair-Search works with two main concepts - Analyzers and Actions.
+	        
+	    Analyzers are cmdlets defined inside .\Analyzers directory. They are executed by Repair-Search in a well-defined order.
+	    These analyzers try to detect any known issues or incorrect configuration in the system. After all analyzers are executed, 
+	    they return one or more recommended actions.
+	    
+	    Actions are cmdlets defined inside .\Actions directory. Actions fix the problem detected earlier by the analyzers.
+	    By default, actions that have high impact on the system are not executed without user confirmation. So, it is safe to execute this script.
+	    If you feel the recommended action should not be executed, you can choose to do so when prompted by this script.
+	    If you want to just check what actions would be executed without actually executing them, pass -WhatIf switch with this script.
+	    If you want to execute all recommended actions without user confirmation, set $ConfirmPreference to 'None'.
+	
+	    Execute Repair-Search. Execute the recommended actions (manual or automated). Repeat this till no more action is recommended.
+	Required Parameters:
+		SQLServerInstance
+		CollectionDatabaseName(ex: AzureDevOps_DefaultCollection)
+		ConfigurationDatabaseName(ex: AzureDevOps_Configuration)
+		CollectionName(ex: DefaultCollection)
+		ElasticsearchServerUrl(URL of Elasticsearch service. Example: http://es-server:9200)
+		ElasticsearchServiceCredential(Credential for connecting to the Elasticsearch service.)
+		EntityType( Code, WorkItem, Wiki or ALL)
+        


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 19 of 20).

Files:
- Troubleshooting/readme.txt
- Troubleshooting/Repair-Search.ps1
- Troubleshooting/SqlScripts/CleanUpCollectionIndexingState.sql
- Troubleshooting/SqlScripts/GetCollectionIndexingUnitDetails.sql
- Troubleshooting/SqlScripts/QueueJob.sql
