### PR TITLE
Add ADO Server 2025 scripts (part 20 of 20)

### DIFF
--- a/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/SearchCollectionProperties.sql
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/SearchCollectionProperties.sql
@@ -1,0 +1,34 @@
+/*
+This script gets the Search URL from the Collection IU's  properties column for given entity
+*/
+
+DECLARE @CollectionId UNIQUEIDENTIFIER = $(CollectionId)
+DECLARE @EntityType VARCHAR(32) = $(EntityType)
+
+SELECT EntityType,
+    CAST(
+    props.query(
+        'declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+        /NS:IndexingProperties/NS:IndexESConnectionString/text()') AS NVARCHAR(MAX)
+    ) AS IndexESConnectionString,
+    CAST(
+    props.query(
+        'declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+        /NS:IndexingProperties/NS:QueryESConnectionString/text()') AS NVARCHAR(MAX)
+    ) AS QueryESConnectionString,
+    CAST(
+    props.query(
+        'declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+        /NS:IndexingProperties/NS:IndexContractType/text()') AS NVARCHAR(MAX)
+    ) AS IndexContractType,
+    CAST(
+    props.query(
+        'declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+        /NS:IndexingProperties/NS:QueryContractType/text()') AS NVARCHAR(MAX)
+    ) AS QueryContractType
+FROM 
+    (
+        SELECT EntityType, CAST(Properties AS xml) AS props
+        FROM Search.tbl_IndexingUnit
+        WHERE PartitionId = 1 AND TFSEntityId = @CollectionId AND EntityType = @EntityType AND IsDeleted = 0
+    ) a

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/SearchIndexingIndices.sql
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/SqlScripts/SearchIndexingIndices.sql
@@ -1,0 +1,22 @@
+-- This script fetches the indexing pipeline as well as query pipeline index names and routing values of all indexing units of a collection of a given entity type
+
+DECLARE @EntityType VARCHAR(32) = $(EntityType)
+
+SELECT 
+    EntityType, 
+    IndexingUnitType, 
+    TfsEntityId,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:IndexIndices/NS1:IndexInfo/NS1:IndexName/text()') AS nvarchar(MAX)) AS IndexingIndexName,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:IndexIndices/NS1:IndexInfo/NS1:Routing/text()') AS nvarchar(MAX)) AS IndexingIndexRouting,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:QueryIndices/NS1:IndexInfo/NS1:IndexName/text()') AS nvarchar(MAX)) AS QueryIndexName,
+    CAST(CAST(Properties AS xml).query('declare namespace NS="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common.Entities.EntityProperties";
+    declare namespace NS1="http://schemas.datacontract.org/2004/07/Microsoft.VisualStudio.Services.Search.Common";
+    /NS:IndexingProperties/NS:QueryIndices/NS1:IndexInfo/NS1:Routing/text()') AS nvarchar(MAX)) AS QueryIndexRouting
+FROM Search.tbl_IndexingUnit
+WHERE PartitionId = 1 AND EntityType = @EntityType AND AssociatedJobId IS NOT NULL AND IsDeleted = 0

--- a/ADO_Server_Diagnostics_2025/Troubleshooting/Utils/Algorithms.ps1
+++ b/ADO_Server_Diagnostics_2025/Troubleshooting/Utils/Algorithms.ps1
@@ -1,0 +1,151 @@
+## Algorithm for detecting cycle in directed graph
+
+# Code inspired from https://www.youtube.com/watch?v=rKQaZuoUR4M
+function Test-CycleInGraph
+{
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [hashtable] $Graph
+    )
+
+    $unvistedVertices = [System.Collections.Generic.HashSet[string]]($Graph.Keys | select )
+    $vistedVerticesInCurrentDfsWalk = New-Object System.Collections.Generic.HashSet[string]
+    $completelyExploredVertices = New-Object System.Collections.Generic.HashSet[string]
+
+    while ($unvistedVertices.Count -gt 0)
+    {
+        $vertex = $unvistedVertices | select -First 1
+        if (Test-DfsPathContainsLoop -Graph $Graph -Vertex $vertex -UnvistedVertices $unvistedVertices -VistedVerticesInCurrentDfsWalk $vistedVerticesInCurrentDfsWalk -CompletelyExploredVertices $completelyExploredVertices)
+        {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-DfsPathContainsLoop
+{
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [hashtable] $Graph,
+
+        [Parameter(Mandatory=$True)]
+        [string] $Vertex,
+
+        [Parameter(Mandatory=$False)]
+        [System.Collections.Generic.HashSet[string]] $UnvistedVertices,
+
+        [Parameter(Mandatory=$False)]
+        [System.Collections.Generic.HashSet[string]] $VistedVerticesInCurrentDfsWalk,
+
+        [Parameter(Mandatory=$False)]
+        [System.Collections.Generic.HashSet[string]] $CompletelyExploredVertices
+    )
+
+    if (!$UnvistedVertices.Remove($Vertex))
+    {
+        throw "Vertex [$Vertex] was expected to be in `$UnvistedVertices but it was not present. Contents of `$UnvistedVertices are [$UnvistedVertices]."
+    }
+
+    if (!$VistedVerticesInCurrentDfsWalk.Add($Vertex))
+    {
+        throw "Vertex [$Vertex] was not expected to be in `$VistedVerticesInCurrentDfsWalk but it was present. Contents of `$VistedVerticesInCurrentDfsWalk are [$VistedVerticesInCurrentDfsWalk]."
+    }
+
+    foreach ($neighbour in $Graph[$Vertex])
+    {
+        if ($VistedVerticesInCurrentDfsWalk.Contains($neighbour))
+        {
+            Write-Log "Found neighbour [$neighbour] of vertex [$Vertex] in the DFS path. Found a loop." -Level Verbose
+            return $true
+        }
+
+        if ($CompletelyExploredVertices.Contains($neighbour))
+        {
+            continue
+        }
+
+        if (Test-DfsPathContainsLoop -Graph $Graph -Vertex $neighbour -UnvistedVertices $UnvistedVertices -VistedVerticesInCurrentDfsWalk $VistedVerticesInCurrentDfsWalk -CompletelyExploredVertices $CompletelyExploredVertices)
+        {
+            return $true
+        }
+    }
+
+    if (!$VistedVerticesInCurrentDfsWalk.Remove($Vertex))
+    {
+        throw "Vertex [$Vertex] was expected to be in `$VistedVerticesInCurrentDfsWalk but it was not present. Contents of `$VistedVerticesInCurrentDfsWalk are [$VistedVerticesInCurrentDfsWalk]."
+    }
+
+    if (!$CompletelyExploredVertices.Add($Vertex))
+    {
+        throw "Vertex [$Vertex] was not expected to be in `$CompletelyExploredVertices but it was present. Contents of `$CompletelyExploredVertices are [$CompletelyExploredVertices]."
+    }
+
+    return $false
+}
+
+## Topological sort algorithm
+
+function Get-TopologicalSort
+{
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [hashtable] $Graph
+    )
+
+    $result = New-Object System.Collections.Generic.Stack[string]
+    $visited = New-Object System.Collections.Generic.HashSet[string]
+
+    foreach ($vertex in $Graph.Keys)
+    {
+        if (!$visited.Contains($vertex))
+        {
+            Invoke-DfsWalk -Graph $Graph -Vertex $vertex -Visited $visited -Result $result
+        }
+    }
+
+    $sortedResult = @()
+    while ($result.Count -gt 0)
+    {
+        $sortedResult += $result.Pop()
+    }
+    
+    return $sortedResult
+}
+
+function Invoke-DfsWalk
+{
+    Param
+    (
+        [Parameter(Mandatory=$True)]
+        [hashtable] $Graph,
+
+        [Parameter(Mandatory=$True)]
+        [string] $Vertex,
+
+        [Parameter(Mandatory=$False)]
+        [System.Collections.Generic.HashSet[string]] $Visited,
+
+        [Parameter(Mandatory=$False)]
+        [System.Collections.Generic.Stack[string]] $Result
+    )
+
+    if (!$Visited.Add($Vertex))
+    {
+        throw "Vertex [$vertex] was not expected to be in `$Visited set already. Contents of `$Visited set = [$Visited]."
+    }
+
+    foreach ($neighbour in $Graph[$Vertex])
+    {
+        if (!$Visited.Contains($neighbour))
+        {
+            Invoke-DfsWalk -Graph $Graph -Vertex $neighbour -Visited $Visited -Result $Result
+        }
+    }
+
+    $Result.Push($Vertex)
+}

--- a/ADO_Server_Diagnostics_2025/ViewDelete-IncompatibleIndices.ps1
+++ b/ADO_Server_Diagnostics_2025/ViewDelete-IncompatibleIndices.ps1
@@ -1,0 +1,96 @@
+﻿<# 
+Execute this script to identify any active indexes that are incompatible. If any indexes are in use, 
+reindex the collection using the TriggerCollection script, and then rerun this script with the Delete action selected.
+#>
+
+param (
+    [Parameter(Mandatory = $true, Position = 0, HelpMessage = "The Server Instance against which the script is to run.")]
+    [string]$SQLServerInstance,
+
+    [Parameter(Mandatory = $true, Position = 1, HelpMessage = "Collection Database name.")]
+    [string]$CollectionDatabaseName,
+
+    [Parameter(Mandatory = $true, Position = 2, HelpMessage = "Elasticsearch URL.")]
+    [string]$URL,
+
+    [Parameter(Mandatory = $true, Position = 3, HelpMessage = "Elasticsearch UserName.")]
+    [string]$UserName,
+
+    [Parameter(Mandatory = $true, Position = 4, HelpMessage = "Elasticsearch Password.")]
+    [string]$Password,
+
+    [Parameter(Mandatory = $true, Position = 5, HelpMessage = "Action to perform.")]
+    [ValidateSet("Delete", "View")]
+    [string]$Action
+)
+
+$indicesFilePath = Join-Path $PSScriptRoot "indices.txt"
+$settingsFilePath = Join-Path $PSScriptRoot "settings.txt"
+$outputFilePath = Join-Path $PSScriptRoot "output.txt"
+
+if (!(Test-Path $indicesFilePath)) {
+    New-Item $indicesFilePath -ItemType File
+}
+
+if (!(Test-Path $settingsFilePath)) {
+    New-Item $settingsFilePath -ItemType File
+}
+
+if (!(Test-Path $outputFilePath)) {
+    New-Item $outputFilePath -ItemType File
+}
+
+$getIndicesCommand = 'curl -u ' + $UserName + ':' + $Password + ' ' + $URL + '/_cat/indices?h=index > ' + $indicesFilePath
+Write-Host $getIndicesCommand
+Start-Process -Verb RunAs cmd.exe -Args '/c', $getIndicesCommand
+
+$indices = Get-Content -Path $indicesFilePath
+
+foreach ($index in $indices) {
+    Remove-Item $settingsFilePath -ErrorAction SilentlyContinue
+    New-Item $settingsFilePath -ItemType File -Force
+
+    $getIndexSettingsCommand = 'curl -u ' + $UserName + ':' + $Password + ' ' + $URL + '/' + $index + '/_settings?pretty -k > ' + $settingsFilePath
+    Write-Host $getIndexSettingsCommand
+    Start-Process -Verb RunAs cmd.exe -Args '/c', $getIndexSettingsCommand
+
+    Start-Sleep -Seconds 1
+
+    $json = Get-Content -Path $settingsFilePath -Raw | ConvertFrom-Json
+    $indexName = $index
+    $createdVersion = $json[0].$indexName.settings.index.version.created
+
+    Write-Host "Index Name: $indexName" -ForegroundColor DarkYellow
+    Write-Host "Created Version for {$indexName}: $createdVersion" -ForegroundColor Green
+
+    $settings = Get-Content -Path $settingsFilePath
+    Add-Content $outputFilePath $settings
+
+    if ($createdVersion.StartsWith("5")) {
+        
+        $Params = "IndexName='$indexName'"
+        $sqlFullPath = Join-Path $PSScriptRoot 'SqlScripts\GetActiveIncompatibleIndex.sql'
+        $result = Invoke-Sqlcmd -InputFile $sqlFullPath -ServerInstance $SQLServerInstance -Database $CollectionDatabaseName -Verbose -Variable $params
+
+        Write-Host "Result: $($result.Count)" -ForegroundColor Red
+
+        foreach ($row in $result) {
+            $TFSEntityId = $row.TFSEntityId
+            $EntityType = $row.EntityType
+            $IndexingUnitType = $row.IndexingUnitType
+            $IndexingUnitId = $row.IndexingUnitId
+
+            Write-Host "TFSEntityId: $TFSEntityId, EntityType: $EntityType, IndexingUnitType: $IndexingUnitType, IndexingUnitId: $IndexingUnitId" -ForegroundColor Red
+        }
+
+        if ($result.Count -eq 0 -and $Action -eq 'Delete') {
+            Write-Host "Deleting Incompatible Index: $indexName" -ForegroundColor Green
+
+            $delCommand = 'curl -u ' + $UserName + ':' + $Password + ' -X DELETE ' + $URL + '/' + $indexName + '?pretty -k'
+            Write-Host $delCommand -ForegroundColor Yellow
+            Start-Process -Verb RunAs cmd.exe -Args '/c', $delCommand
+        }
+    }
+
+    Start-Sleep -Seconds 2
+}

--- a/ADO_Server_Diagnostics_2025/WipeOutAndResetElasticSearch.ps1
+++ b/ADO_Server_Diagnostics_2025/WipeOutAndResetElasticSearch.ps1
@@ -1,0 +1,128 @@
+﻿# Azure DevOps Server 2025 - Elasticsearch 8.14
+# Script to wipe out and reset Elasticsearch for Azure DevOps Server 2025
+#
+# PURPOSE: Completely removes and resets Elasticsearch service and data.
+#          Use this when Elasticsearch is corrupted or needs a fresh start.
+#
+# WARNING: *** THIS WILL DELETE ALL SEARCH INDICES AND DATA ***
+#          - All search functionality will be lost
+#          - Re-indexing will be required after running this script
+#          - Run only when other repair methods have failed
+#
+# REQUIREMENTS:
+#          - Must run as Administrator
+#          - Elasticsearch service must be installed on the local machine
+#
+# USAGE: Run without parameters. The script will guide you through the process.
+#        .\WipeOutAndResetElasticSearch.ps1
+#
+# NEXT STEPS AFTER RUNNING:
+#          1. Reconfigure search in Azure DevOps Server Administration Console
+#          2. Trigger re-indexing for all collections using TriggerCollectionIndexing.ps1
+#
+function IsCurrentUserAdmin
+{
+    [CmdletBinding()]
+    param()
+
+    If (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
+    {
+	    return $true
+    }
+    return $false
+}
+
+function IsResetConfirm
+{
+    [OutputType([boolean])]
+    Param
+    (
+    [string]$message
+    )
+    Write-Host $message  -NoNewline -ForegroundColor Magenta
+    $confirm = Read-Host 
+    if ($confirm.ToUpper().StartsWith(“Y”))
+    {
+    return $true
+    }
+    return $false
+}
+
+function GetElasticsearchInstallPath
+{
+    param
+    (
+    [string] $serviceName
+    )
+
+    $output = Get-WmiObject win32_service | ?{$_.Name -like $serviceName} | select PathName
+
+    if($output)
+    {
+        $pathTokens = $output.PathName -split '"'
+        $servicePath = if ($pathTokens.Length -gt 1) { $pathTokens[1] } else { ($output.PathName -split ' ')[0] }
+        $servicePath = Split-Path -Path $servicePath
+    }
+
+    return $servicePath
+}
+
+if(-not (IsCurrentUserAdmin))
+{
+    Write-Error "Run the script with Admin privileges"
+    Exit
+}
+
+$message = "This can be fatal!!. It will delete current indexed data for all the collections. Do you want to continue - Yes(Y) or No(N)? "
+
+if(IsResetConfirm($message))
+{
+    # Getting the install path of the Team Foundation Server
+    $serviceName = 'elasticsearch-service-x64'
+    
+    $servicePath = GetElasticsearchInstallPath($serviceName)
+
+    if(-not $servicePath)
+    {
+            $ESIndexLocation = $env:SEARCH_ES_INDEX_PATH
+            if(-not $ESIndexLocation)
+            {
+                Remove-Item -Recurse -Force -Path $ESIndexLocation
+                Write-Host "Cleaned up the index folder $ESIndexLocation" -ForegroundColor Green
+            }
+            else
+            {
+                Write-Host "Could not find ElasticSearch service or data. Exiting cleanup" -ForegroundColor Yellow
+            }
+    }
+    else
+    {
+        [System.ENVIRONMENT]::CurrentDirectory = $pwd
+        Write-Host "Found ElasticSearch at $servicePath" -ForegroundColor Green
+        Push-Location
+
+        cd $servicePath
+        $outputService = .\elasticsearch-service.bat stop 
+        Write-Host $outputService -ForegroundColor Yellow
+        if($outputService -like '*failed*')
+        {
+            Write-Host "Failed to stop service. Exiting cleanup" -ForegroundColor Yellow
+        }
+        else
+        {
+            $ESIndexLocation = $env:SEARCH_ES_INDEX_PATH
+            Remove-Item -Recurse -Force -Path $ESIndexLocation
+
+            Write-Host "Cleaned up the index folder $ESIndexLocation" -ForegroundColor Green
+
+            $outputService = .\elasticsearch-service.bat start
+            Write-Host $outputService -ForegroundColor Yellow
+        }
+
+        Pop-Location 
+    }
+}
+else
+{
+    Write-Warning "Exiting! ElasticSearch was not reset."
+}


### PR DESCRIPTION
Adds Azure DevOps Server 2025 search administration scripts (part 20 of 20).

Files:
- Troubleshooting/SqlScripts/SearchCollectionProperties.sql
- Troubleshooting/SqlScripts/SearchIndexingIndices.sql
- Troubleshooting/Utils/Algorithms.ps1
- ViewDelete-IncompatibleIndices.ps1
- WipeOutAndResetElasticSearch.ps1
